### PR TITLE
Implement forgot/reset password endpoints

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
 
   api-pgd:
     image: ghcr.io/gestaogovbr/api-pgd:latest
-    pull_policy: always
     container_name: api-pgd
     depends_on:
       db:
@@ -40,8 +39,24 @@ services:
       # to new `SECRET` run openssl rand -hex 32
       SECRET: b8a3054ba3457614e95a88cc0807384430c1b338a54e95e4245f41e060da68bc
       ACCESS_TOKEN_EXPIRE_MINUTES: 30
+      MAIL_USERNAME: ''
+      MAIL_FROM: admin@api-pgd.gov.br
+      MAIL_PORT: 25
+      MAIL_SERVER: smtp4dev
+      MAIL_FROM_NAME: admin@api-pgd.gov.br
+      MAIL_PASSWORD: ''  
     healthcheck:
       test: ["CMD", "curl", "-f", "http://0.0.0.0:5057/docs"]
       interval: 5s
       timeout: 5s
       retries: 20
+
+  smtp4dev:
+    image: rnwood/smtp4dev:v3
+    restart: always
+    ports:
+      - '5000:80'
+      - '25:25' # Change the number before : to the port the SMTP server should be accessible on
+      - '143:143' # Change the number before : to the port the IMAP server should be accessible on
+    environment:
+      - ServerOptions__HostName=smtp4dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ httpx==0.24.1
 python-jose[cryptography]==3.3.0
 passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
+fastapi-mail==1.4.1

--- a/src/api.py
+++ b/src/api.py
@@ -304,11 +304,6 @@ async def create_or_update_plano_entregas(
     plano_entregas: schemas.PlanoEntregasSchema,
     response: Response,
     db: DbContextManager = Depends(DbContextManager),
-    # TODO: Obter meios de verificar permissão opcional. O código abaixo
-    #       bloqueia o acesso, mesmo informando que é opcional.
-    # access_token_info: Optional[FiefAccessTokenInfo] = Depends(
-    #     auth_backend.authenticated(permissions=["all:read"], optional=True)
-    # ),
 ):
     """Cria um novo plano de entregas ou, se existente, substitui um
     plano de entregas por um novo com os dados informados."""
@@ -432,11 +427,6 @@ async def create_or_update_plano_trabalho(
     plano_trabalho: schemas.PlanoTrabalhoSchema,
     response: Response,
     db: DbContextManager = Depends(DbContextManager),
-    # TODO: Obter meios de verificar permissão opcional. O código abaixo
-    #       bloqueia o acesso, mesmo informando que é opcional.
-    # access_token_info: Optional[FiefAccessTokenInfo] = Depends(
-    #     auth_backend.authenticated(permissions=["all:read"], optional=True)
-    # ),
 ):
     """Cria um novo plano de trabalho ou, se existente, substitui um
     plano de trabalho por um novo com os dados informados."""

--- a/src/api.py
+++ b/src/api.py
@@ -106,10 +106,10 @@ async def login_for_access_token(
     tags=["Auth"],
 )
 async def get_users(
-    user_logged: Annotated[
+    user_logged: Annotated[ # pylint: disable=unused-argument
         schemas.UsersSchema,
         Depends(crud_auth.get_current_admin_user),
-    ],  # pylint: disable=unused-argument
+    ],
     db: DbContextManager = Depends(DbContextManager),
 ) -> list[schemas.UsersGetSchema]:
     return await crud_auth.get_all_users(db)
@@ -121,9 +121,9 @@ async def get_users(
     tags=["Auth"],
 )
 async def create_or_update_user(
-    user_logged: Annotated[
+    user_logged: Annotated[  # pylint: disable=unused-argument
         schemas.UsersSchema, Depends(crud_auth.get_current_admin_user)
-    ],  # pylint: disable=unused-argument
+    ],
     user: schemas.UsersSchema,
     email: str,
     db: DbContextManager = Depends(DbContextManager),
@@ -171,10 +171,10 @@ async def create_or_update_user(
     tags=["Auth"],
 )
 async def get_user(
-    user_logged: Annotated[
+    user_logged: Annotated[  # pylint: disable=unused-argument
         schemas.UsersSchema,
         Depends(crud_auth.get_current_admin_user),
-    ],  # pylint: disable=unused-argument
+    ],
     email: str,
     db: DbContextManager = Depends(DbContextManager),
 ) -> schemas.UsersGetSchema:

--- a/src/api.py
+++ b/src/api.py
@@ -41,6 +41,7 @@ app = FastAPI(
     version=os.environ["TAG_NAME"],
 )
 
+
 @app.on_event("startup")
 async def on_startup():
     await create_db_and_tables()
@@ -113,7 +114,6 @@ async def get_users(
     ],
     db: DbContextManager = Depends(DbContextManager),
 ) -> list[schemas.UsersGetSchema]:
-
     return await crud_auth.get_all_users(db)
 
 
@@ -124,8 +124,7 @@ async def get_users(
 )
 async def create_or_update_user(
     user_logged: Annotated[
-        schemas.UsersSchema,
-        Depends(crud_auth.get_current_admin_user)
+        schemas.UsersSchema, Depends(crud_auth.get_current_admin_user)
     ],
     user: schemas.UsersSchema,
     email: str,
@@ -220,6 +219,7 @@ async def delete_user(
             detail=f"IntegrityError: {str(exception)}",
         ) from exception
 
+
 @app.post(
     "/user/forgot_password/{email}",
     summary="Recuperação de Acesso",
@@ -228,20 +228,22 @@ async def delete_user(
 async def forgot_password(
     email: str,
     db: DbContextManager = Depends(DbContextManager),
-    ) -> schemas.UsersInputSchema:
-
+) -> schemas.UsersInputSchema:
     user = await crud_auth.get_user(db, email)
 
     if user:
         access_token_expires = timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-        access_token = crud_auth.create_access_token(data={"sub": user.email}, expires_delta=access_token_expires)
-        
+        access_token = crud_auth.create_access_token(
+            data={"sub": user.email}, expires_delta=access_token_expires
+        )
+
         return await email_config.send_reset_password_mail(email, access_token)
-            
+
     else:
         raise HTTPException(
             status.HTTP_404_NOT_FOUND, detail=f"Usuário `{email}` não existe"
         )
+
 
 @app.get(
     "/user/reset_password/",
@@ -252,8 +254,7 @@ async def reset_password(
     access_token: str,
     password: str,
     db: DbContextManager = Depends(DbContextManager),
-    ):
-
+):
     """
     Gera uma nova senha através do token fornecido por email.
     """
@@ -261,10 +262,8 @@ async def reset_password(
         return await crud_auth.user_reset_password(db, access_token, password)
 
     except ValueError as e:
-        raise HTTPException(
-            status_code=400, detail=f"{e}")
-       
-  
+        raise HTTPException(status_code=400, detail=f"{e}")
+
 
 # ## DATA --------------------------------------------------
 

--- a/src/api.py
+++ b/src/api.py
@@ -11,12 +11,10 @@ from fastapi import Depends, FastAPI, HTTPException, status, Header, Response
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.responses import RedirectResponse
 from sqlalchemy.exc import IntegrityError
-from fastapi_mail import FastMail, MessageSchema, MessageType
 
 
 import schemas
 import crud
-import logging
 from db_config import DbContextManager, create_db_and_tables
 import crud_auth
 from create_admin_user import init_user_admin
@@ -111,7 +109,7 @@ async def get_users(
     user_logged: Annotated[
         schemas.UsersSchema,
         Depends(crud_auth.get_current_admin_user),
-    ],
+    ],  # pylint: disable=unused-argument
     db: DbContextManager = Depends(DbContextManager),
 ) -> list[schemas.UsersGetSchema]:
     return await crud_auth.get_all_users(db)
@@ -125,7 +123,7 @@ async def get_users(
 async def create_or_update_user(
     user_logged: Annotated[
         schemas.UsersSchema, Depends(crud_auth.get_current_admin_user)
-    ],
+    ],  # pylint: disable=unused-argument
     user: schemas.UsersSchema,
     email: str,
     db: DbContextManager = Depends(DbContextManager),
@@ -176,7 +174,7 @@ async def get_user(
     user_logged: Annotated[
         schemas.UsersSchema,
         Depends(crud_auth.get_current_admin_user),
-    ],
+    ],  # pylint: disable=unused-argument
     email: str,
     db: DbContextManager = Depends(DbContextManager),
 ) -> schemas.UsersGetSchema:
@@ -239,10 +237,9 @@ async def forgot_password(
 
         return await email_config.send_reset_password_mail(email, access_token)
 
-    else:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, detail=f"Usuário `{email}` não existe"
-        )
+    raise HTTPException(
+        status.HTTP_404_NOT_FOUND, detail=f"Usuário `{email}` não existe"
+    )
 
 
 @app.get(
@@ -262,7 +259,7 @@ async def reset_password(
         return await crud_auth.user_reset_password(db, access_token, password)
 
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=f"{e}")
+        raise HTTPException(status_code=400, detail=f"{e}") from e
 
 
 # ## DATA --------------------------------------------------

--- a/src/api.py
+++ b/src/api.py
@@ -228,7 +228,7 @@ async def delete_user(
 async def forgot_password(
     email: str,
     db: DbContextManager = Depends(DbContextManager),
-    ) -> schemas.UsersGetSchema:
+    ) -> schemas.UsersInputSchema:
 
     user = await crud_auth.get_user(db, email)
 
@@ -243,39 +243,28 @@ async def forgot_password(
             status.HTTP_404_NOT_FOUND, detail=f"Usuário `{email}` não existe"
         )
 
-@app.post(
-    "/user/reset_password/{email}",
-    summary="Criar nova senha",
+@app.get(
+    "/user/reset_password/",
+    summary="Criar nova senha a partir do token de acesso",
     tags=["Auth"],
 )
 async def reset_password(
-    token: str,
+    access_token: str,
     password: str,
-    user: Annotated[
-        schemas.UsersSchema,
-        Depends(crud_auth.get_current_user),
-    ],  
     db: DbContextManager = Depends(DbContextManager),
-    ) -> schemas.UsersGetSchema:
+    ):
 
     """
-    Resets password for a user.
+    Gera uma nova senha através do token fornecido por email.
     """
     try:
-        await crud_auth.user_reset_password(db, user.email, password)
-        return {"Senha alterada"}
+        return await crud_auth.user_reset_password(db, access_token, password)
 
     except ValueError as e:
         raise HTTPException(
             status_code=400, detail=f"{e}")
-    except Exception as e:
-        raise HTTPException(
-            status_code=500, detail=f"{e}")                
-            
-    else:
-        raise HTTPException(
-            status.HTTP_404_NOT_FOUND, detail=f"Usuário `{email}` não existe"
-        )    
+       
+  
 
 # ## DATA --------------------------------------------------
 

--- a/src/crud_auth.py
+++ b/src/crud_auth.py
@@ -93,11 +93,7 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
 
     return encoded_jwt
 
-
-async def get_current_user(
-    token: Annotated[str, Depends(oauth2_scheme)],
-    db: DbContextManager = Depends(DbContextManager),
-):
+async def verify_token(token: str, db: DbContextManager):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Credenciais não podem ser validadas",
@@ -119,6 +115,18 @@ async def get_current_user(
         raise credentials_exception
 
     return user
+
+async def get_current_user(
+    token: Annotated[str, Depends(oauth2_scheme)],
+    db: DbContextManager = Depends(DbContextManager),
+):
+    return await verify_token(token, db)
+
+async def get_user_by_token(
+    token: str,
+    db: DbContextManager = Depends(DbContextManager),
+):
+    return await verify_token(token, db)
 
 
 async def get_current_active_user(
@@ -236,15 +244,28 @@ async def delete_user(
     return f"Usuário `{email}` deletado"
 
 async def user_reset_password(db_session: DbContextManager, 
-                              user: schemas.UsersSchema,
-                              email: str, 
-                              new_password: str):
+                              token: str,
+                              new_password: str) -> str:
+    """Reset password of a user by passing a access token.
+
+    Args:
+        db_session (DbContextManager): Session with api database
+        token (str): access token sended by email
+        new_password (str): the new password for encryption
+
+    Returns:
+        str: Message about updated password
+    """    
     
+
+    user = await get_user_by_token(token, db_session)
+
     user.password = get_password_hash(new_password)
+
     async with db_session as session:
         await session.execute(
-            update(models.Users).filter_by(email=email).values(**user.model_dump())
+            update(models.Users).filter_by(email=user.email).values(**user.model_dump())
         )
         await session.commit()
 
-    return schemas.UsersSchema.model_validate(user)
+    return f"Senha do Usuário {user.email} atualizada"

--- a/src/crud_auth.py
+++ b/src/crud_auth.py
@@ -234,3 +234,17 @@ async def delete_user(
         await session.commit()
 
     return f"Usuário `{email}` deletado"
+
+async def user_reset_password(db_session: DbContextManager, 
+                              user: schemas.UsersSchema,
+                              email: str, 
+                              new_password: str):
+    
+    user.password = get_password_hash(new_password)
+    async with db_session as session:
+        await session.execute(
+            update(models.Users).filter_by(email=email).values(**user.model_dump())
+        )
+        await session.commit()
+
+    return schemas.UsersSchema.model_validate(user)

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -20,6 +20,19 @@ conf = ConnectionConfig(
 async def send_reset_password_mail(email: str, 
                                    token: str, 
                                    ) -> JSONResponse:
+    """Envia o e-mail contendo token para redefinir a senha.
+
+    Args:
+        email (str): o email do usuário.
+        token (str): o token para redefinir a senha.
+
+    Raises:
+        e: exceção gerada pelo FastAPI Mail.
+
+    Returns:
+        JSONResponse: resposta retornada para o endpoint.
+    """
+    token_expiration_minutes = os.environ["ACCESS_TOKEN_EXPIRE_MINUTES"]
     body = f"""
             <html>
             <body>

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -1,0 +1,46 @@
+import os
+import logging
+from fastapi_mail import FastMail, MessageSchema, ConnectionConfig, MessageType
+from starlette.responses import JSONResponse
+from typing import List
+
+conf = ConnectionConfig(
+    MAIL_USERNAME=os.environ["MAIL_USERNAME"],
+    MAIL_FROM=os.environ["MAIL_FROM"],
+    MAIL_PORT=os.environ["MAIL_PORT"],
+    MAIL_SERVER=os.environ["MAIL_SERVER"],
+    MAIL_FROM_NAME=os.environ["MAIL_FROM_NAME"],
+    MAIL_STARTTLS=False,
+    MAIL_SSL_TLS=False,
+    MAIL_PASSWORD=os.environ["MAIL_PASSWORD"],
+    USE_CREDENTIALS=False,
+    VALIDATE_CERTS=False
+)
+
+async def send_reset_password_mail(email: str, 
+                                   token: str, 
+                                   ) -> JSONResponse:
+    body = f"""
+            <html>
+            <body>
+            <h3>Recuperação de acesso</h3>
+            <p>Olá, {email}.</p>
+            <p>Você esqueceu sua senha da API PGD.
+            Segue o token para geração de nova senha: <br/> {token}
+            </p>
+            </body>
+            </html>
+            """
+    try:
+        message = MessageSchema(
+            subject="Recuperação de acesso",
+            recipients=[email],
+            body=body,
+            subtype=MessageType.html
+        )
+        fm = FastMail(conf)
+        await fm.send_message(message)
+        return JSONResponse(status_code=200, content={"message": "Email enviado!"})
+    except Exception as e:
+        logging.error("Erro ao enviar o email %e", e)
+        

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -66,5 +66,4 @@ async def send_reset_password_mail(email: str,
         return JSONResponse(status_code=200, content={"message": "Email enviado!"})
     except (DBProvaiderError, ConnectionErrors, ApiError) as e:
         logging.error("Erro ao enviar o email %e", e)
-    finally:
         raise e

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -34,16 +34,26 @@ async def send_reset_password_mail(email: str,
     """
     token_expiration_minutes = os.environ["ACCESS_TOKEN_EXPIRE_MINUTES"]
     body = f"""
-            <html>
-            <body>
+        <html>
+          <body>
             <h3>Recuperação de acesso</h3>
             <p>Olá, {email}.</p>
-            <p>Você esqueceu sua senha da API PGD.
-            Segue o token para geração de nova senha: <br/> {token}
-            </p>
-            </body>
-            </html>
-            """
+            <p>Foi solicitada a recuperação de sua senha da API PGD.
+            Caso essa solicitação não tenha sido feita por você, por
+            favor ignore esta mensagem.</p>
+            <p>Foi gerado o seguinte token para geração de uma nova
+            senha.</p>
+            <dl>
+              <dt>Token</dt>
+              <dd><code>{token}</code></dd>
+              <dt>Prazo de validade</dt>
+              <dd>{token_expiration_minutes} minutos</dd>
+            </dl>
+            <p>Utilize o endpoint <code>/user/reset_password</code> com
+            este token para redefinir a senha.</p>
+          </body>
+        </html>
+    """
     try:
         message = MessageSchema(
             subject="Recuperação de acesso",

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -1,8 +1,8 @@
 import os
 import logging
 from fastapi_mail import FastMail, MessageSchema, ConnectionConfig, MessageType
+from fastapi_mail.errors import DBProvaiderError, ConnectionErrors, ApiError
 from starlette.responses import JSONResponse
-from typing import List
 
 conf = ConnectionConfig(
     MAIL_USERNAME=os.environ["MAIL_USERNAME"],
@@ -41,6 +41,7 @@ async def send_reset_password_mail(email: str,
         fm = FastMail(conf)
         await fm.send_message(message)
         return JSONResponse(status_code=200, content={"message": "Email enviado!"})
-    except Exception as e:
+    except (DBProvaiderError, ConnectionErrors, ApiError) as e:
         logging.error("Erro ao enviar o email %e", e)
-        
+    finally:
+        raise e

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,6 +121,7 @@ def delete_user(username: str, password: str, del_user_email: str) -> httpx.Resp
 
     return response
 
+
 def create_user(username: str, password: str, new_user: dict) -> httpx.Response:
     """_summary_
 
@@ -135,7 +136,9 @@ def create_user(username: str, password: str, new_user: dict) -> httpx.Response:
 
     headers = prepare_header(username, password)
     new_user_pop = {key: value for key, value in new_user.items() if key != "username"}
-    response = httpx.put(f"{API_BASE_URL}/user/{new_user['email']}", headers=headers, json=new_user_pop)
+    response = httpx.put(
+        f"{API_BASE_URL}/user/{new_user['email']}", headers=headers, json=new_user_pop
+    )
     response.raise_for_status()
 
     return response
@@ -269,7 +272,9 @@ def fixture_truncate_users(admin_credentials: dict):
     ):
         if del_user_email != admin_credentials["username"]:
             response = delete_user(
-                admin_credentials["username"], admin_credentials["password"], del_user_email
+                admin_credentials["username"],
+                admin_credentials["password"],
+                del_user_email,
             )
             response.raise_for_status()
 
@@ -280,7 +285,9 @@ def fixture_register_user_1(
     user1_credentials: dict,
     admin_credentials: dict,
 ) -> httpx.Response:
-    response = create_user(admin_credentials["username"], admin_credentials["password"], user1_credentials)
+    response = create_user(
+        admin_credentials["username"], admin_credentials["password"], user1_credentials
+    )
     response.raise_for_status()
 
     return response
@@ -292,10 +299,13 @@ def fixture_register_user_2(
     user2_credentials: dict,
     admin_credentials: dict,
 ) -> httpx.Response:
-    response = create_user(admin_credentials["username"], admin_credentials["password"], user2_credentials)
+    response = create_user(
+        admin_credentials["username"], admin_credentials["password"], user2_credentials
+    )
     response.raise_for_status()
 
     return response
+
 
 @pytest.fixture(scope="module")
 def header_not_logged_in() -> dict:

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -65,6 +65,7 @@ def test_get_all_users_logged_in_admin(client: Client, header_usr_1: dict):
     response = client.get("/users", headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
 
+
 # get /user
 def test_get_user_not_logged_in(client: Client, header_not_logged_in: dict):
     response = client.get("/user/foo@oi.com", headers=header_not_logged_in)
@@ -72,32 +73,26 @@ def test_get_user_not_logged_in(client: Client, header_not_logged_in: dict):
 
 
 def test_get_user_logged_in_not_admin(
-    client: Client, user2_credentials: dict, header_usr_2: dict # user is_admin=False
+    client: Client, user2_credentials: dict, header_usr_2: dict  # user is_admin=False
 ):
     response = client.get(f"/user/{user2_credentials['email']}", headers=header_usr_2)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_get_user_as_admin(
-    client: Client,
-    user1_credentials: dict,
-    header_usr_1: dict # user is_admin=True
+    client: Client, user1_credentials: dict, header_usr_1: dict  # user is_admin=True
 ):
     response = client.get(f"/user/{user1_credentials['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
 
 
-def test_get_user_not_exists(
-    client: Client, header_usr_1: dict # user is_admin=True
-):
+def test_get_user_not_exists(client: Client, header_usr_1: dict):  # user is_admin=True
     response = client.get(f"/user/{USERS_TEST[1]['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_get_user_self_logged_in(
-    client: Client,
-    user1_credentials: dict,
-    header_usr_1: dict # user is_admin=True
+    client: Client, user1_credentials: dict, header_usr_1: dict  # user is_admin=True
 ):
     response = client.get(f"/user/{user1_credentials['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
@@ -116,15 +111,16 @@ def test_get_user_self_logged_in(
 # create /user
 def test_create_user_not_logged_in(client: Client, header_not_logged_in: dict):
     response = client.put(
-        f"/user/{USERS_TEST[0]['email']}", headers=header_not_logged_in, json=USERS_TEST[0]
+        f"/user/{USERS_TEST[0]['email']}",
+        headers=header_not_logged_in,
+        json=USERS_TEST[0],
     )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_create_user_logged_in_not_admin(
-        client: Client,
-        header_usr_2: dict # user is_admin=False
-    ):
+    client: Client, header_usr_2: dict  # user is_admin=False
+):
     response = client.put(
         f"/user/{USERS_TEST[0]['email']}", headers=header_usr_2, json=USERS_TEST[0]
     )
@@ -132,9 +128,8 @@ def test_create_user_logged_in_not_admin(
 
 
 def test_create_user_logged_in_admin(
-        client: Client,
-        header_usr_1: dict # user is_admin=True
-    ):
+    client: Client, header_usr_1: dict  # user is_admin=True
+):
     response = client.put(
         f"/user/{USERS_TEST[0]['email']}", headers=header_usr_1, json=USERS_TEST[0]
     )
@@ -142,9 +137,8 @@ def test_create_user_logged_in_admin(
 
 
 def test_create_user_without_required_fields(
-        client: Client,
-        header_usr_1: dict # user is_admin=True
-    ):
+    client: Client, header_usr_1: dict  # user is_admin=True
+):
     response = client.put(
         f"/user/{USERS_TEST[2]['email']}", headers=header_usr_1, json=USERS_TEST[2]
     )
@@ -152,8 +146,7 @@ def test_create_user_without_required_fields(
 
 
 def test_create_user_bad_email_format(
-    client: Client,
-    header_usr_1: dict # user is_admin=True
+    client: Client, header_usr_1: dict  # user is_admin=True
 ):
     response = client.put(
         f"/user/{USERS_TEST[3]['email']}", headers=header_usr_1, json=USERS_TEST[3]
@@ -162,10 +155,7 @@ def test_create_user_bad_email_format(
 
 
 # update /user
-def test_update_user(
-        client: Client,
-        header_usr_1: dict # user is_admin=True
-    ):
+def test_update_user(client: Client, header_usr_1: dict):  # user is_admin=True
     # get
     r_1 = client.get(f"/user/{USERS_TEST[0]['email']}", headers=header_usr_1)
     data_before = r_1.json()
@@ -183,53 +173,52 @@ def test_update_user(
     r_3 = client.get(f"/user/{USERS_TEST[0]['email']}", headers=header_usr_1)
     data_after = r_3.json()
 
-    assert data_before.get("cod_SIAPE_instituidora", None) == data_after.get("cod_SIAPE_instituidora", None)
+    assert data_before.get("cod_SIAPE_instituidora", None) == data_after.get(
+        "cod_SIAPE_instituidora", None
+    )
 
 
 # delete /user
 def test_delete_user_not_logged_in(client: Client, header_not_logged_in: dict):
     response = client.delete(
-        f"/user/{USERS_TEST[0]['email']}", headers=header_not_logged_in)
+        f"/user/{USERS_TEST[0]['email']}", headers=header_not_logged_in
+    )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_delete_user_logged_in_not_admin(
-        client: Client,
-        header_usr_2: dict # user is_admin=False
-    ):
-    response = client.delete(
-        f"/user/{USERS_TEST[0]['email']}", headers=header_usr_2)
+    client: Client, header_usr_2: dict  # user is_admin=False
+):
+    response = client.delete(f"/user/{USERS_TEST[0]['email']}", headers=header_usr_2)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
 def test_delete_user_logged_in_admin(
-        client: Client,
-        header_usr_1: dict # user is_admin=True
-    ):
-    response = client.delete(
-        f"/user/{USERS_TEST[0]['email']}", headers=header_usr_1)
+    client: Client, header_usr_1: dict  # user is_admin=True
+):
+    response = client.delete(f"/user/{USERS_TEST[0]['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_200_OK
 
 
 def test_delete_user_not_exists_logged_in_admin(
-        client: Client,
-        header_usr_1: dict # user is_admin=True
-    ):
-    response = client.delete(
-        f"/user/{USERS_TEST[1]['email']}", headers=header_usr_1)
+    client: Client, header_usr_1: dict  # user is_admin=True
+):
+    response = client.delete(f"/user/{USERS_TEST[1]['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_404_NOT_FOUND
 
 
 def test_delete_yourself(client: Client, user1_credentials: dict, header_usr_1: dict):
     response = client.delete(
-        f"/user/{user1_credentials['email']}", headers=header_usr_1)
+        f"/user/{user1_credentials['email']}", headers=header_usr_1
+    )
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
 
 # forgot/reset password
 
-def test_forgot_password(client: Client, 
-                         user1_credentials: dict, 
-                         header_usr_1: dict):
+
+def test_forgot_password(client: Client, user1_credentials: dict, header_usr_1: dict):
     response = client.post(
-        f"/user/forgot_password/{user1_credentials['email']}", headers=header_usr_1)
+        f"/user/forgot_password/{user1_credentials['email']}", headers=header_usr_1
+    )
     assert response.status_code == status.HTTP_200_OK

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -228,7 +228,7 @@ def get_all_mailbox_messages(
     host: str = "localhost",
     user: str = "smtp4dev",
     password: str = "",
-) -> Generator[email.message.Message]:
+) -> Generator[email.message.Message, None, None]:
     """Get messages from the mailbox.
 
     Args:

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -224,3 +224,12 @@ def test_delete_yourself(client: Client, user1_credentials: dict, header_usr_1: 
     response = client.delete(
         f"/user/{user1_credentials['email']}", headers=header_usr_1)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+# forgot/reset password
+
+def test_forgot_password(client: Client, 
+                         user1_credentials: dict, 
+                         header_usr_1: dict):
+    response = client.post(
+        f"/user/forgot_password/{user1_credentials['email']}", headers=header_usr_1)
+    assert response.status_code == status.HTTP_200_OK

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -353,7 +353,7 @@ def test_forgot_password(
     user1_credentials: dict,
     header_usr_1: dict,
 ):
-    """Tests the forgot and reset password functonality."""
+    """Tests the forgot and reset password functionality."""
     # use the forgot_password endpoint to send an email
     response = client.post(
         f"/user/forgot_password/{user1_credentials['email']}", headers=header_usr_1

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -353,7 +353,7 @@ def test_forgot_password(client: Client, user1_credentials: dict, header_usr_1: 
     )
     assert response.status_code == status.HTTP_200_OK
 
-    access_token = get_token_from_email()
+    access_token = get_token_from_email(host="smtp4dev")
     new_password = "new_password_for_test"
     response = client.get(
         "/user/reset_password/",

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -225,7 +225,7 @@ def test_delete_yourself(client: Client, user1_credentials: dict, header_usr_1: 
 
 
 def get_all_mailbox_messages(
-    host: str = "localhost",
+    host: str = "smtp4dev",
     user: str = "smtp4dev",
     password: str = "",
 ) -> Generator[email.message.Message, None, None]:
@@ -277,7 +277,7 @@ def get_latest_message_uid(messages: dict[int, email.message.Message]) -> str:
 
 def get_message_body(
     uid: int,
-    host: str = "localhost",
+    host: str = "smtp4dev",
     user: str = "smtp4dev",
     password: str = "",
 ) -> str:
@@ -328,7 +328,7 @@ def get_token_from_content(content: str) -> str:
 
 
 def get_token_from_email(
-    host: str = "localhost",
+    host: str = "smtp4dev",
     user: str = "smtp4dev",
     password: str = "",
 ) -> str:
@@ -344,7 +344,7 @@ def get_token_from_email(
     """
     messages = dict(enumerate(get_all_mailbox_messages(host, user, password), start=1))
     latest_message = get_latest_message_uid(messages)
-    return get_token_from_content(get_message_body(latest_message))
+    return get_token_from_content(get_message_body(uid=latest_message, host=host))
 
 
 def test_forgot_password(client: Client, user1_credentials: dict, header_usr_1: dict):


### PR DESCRIPTION
Implement reset password function in API:

- Introduce a new **smtp4dev** container for development deployment in docker-compose
- Include **fastapi-mail 1.4.1** in _requirements.txt_
- Establish the _email_config.py_ file containing SMTP environment variables and email templates.
- Develop methods for **forgot password** (sending a email to the user with a token) and **reset password** (resetting the password using the token)
- Create tests for forgot_password

TODO: 
- Create tests for reset_password (needs to catch the token in the email body)