### PR TITLE
Make some fields in Entrega mandatory and add some tests

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -106,7 +106,7 @@ async def login_for_access_token(
     tags=["Auth"],
 )
 async def get_users(
-    user_logged: Annotated[ # pylint: disable=unused-argument
+    user_logged: Annotated[  # pylint: disable=unused-argument
         schemas.UsersSchema,
         Depends(crud_auth.get_current_admin_user),
     ],

--- a/src/create_admin_user.py
+++ b/src/create_admin_user.py
@@ -7,6 +7,7 @@ from models import Users
 API_PGD_ADMIN_USER = os.environ.get("API_PGD_ADMIN_USER")
 API_PGD_ADMIN_PASSWORD = os.environ.get("API_PGD_ADMIN_PASSWORD")
 
+
 async def init_user_admin():
     db_session = async_session_maker()
 
@@ -16,7 +17,7 @@ async def init_user_admin():
             # b-crypt
             password=get_password_hash(API_PGD_ADMIN_PASSWORD),
             is_admin=True,
-            cod_SIAPE_instituidora=1
+            cod_SIAPE_instituidora=1,
         )
 
         async with db_session as session:

--- a/src/crud_auth.py
+++ b/src/crud_auth.py
@@ -93,6 +93,7 @@ def create_access_token(data: dict, expires_delta: timedelta | None = None):
 
     return encoded_jwt
 
+
 async def verify_token(token: str, db: DbContextManager):
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
@@ -116,11 +117,13 @@ async def verify_token(token: str, db: DbContextManager):
 
     return user
 
+
 async def get_current_user(
     token: Annotated[str, Depends(oauth2_scheme)],
     db: DbContextManager = Depends(DbContextManager),
 ):
     return await verify_token(token, db)
+
 
 async def get_user_by_token(
     token: str,
@@ -243,9 +246,10 @@ async def delete_user(
 
     return f"Usuário `{email}` deletado"
 
-async def user_reset_password(db_session: DbContextManager, 
-                              token: str,
-                              new_password: str) -> str:
+
+async def user_reset_password(
+    db_session: DbContextManager, token: str, new_password: str
+) -> str:
     """Reset password of a user by passing a access token.
 
     Args:
@@ -255,8 +259,7 @@ async def user_reset_password(db_session: DbContextManager,
 
     Returns:
         str: Message about updated password
-    """    
-    
+    """
 
     user = await get_user_by_token(token, db_session)
 

--- a/src/email_config.py
+++ b/src/email_config.py
@@ -14,12 +14,14 @@ conf = ConnectionConfig(
     MAIL_SSL_TLS=False,
     MAIL_PASSWORD=os.environ["MAIL_PASSWORD"],
     USE_CREDENTIALS=False,
-    VALIDATE_CERTS=False
+    VALIDATE_CERTS=False,
 )
 
-async def send_reset_password_mail(email: str, 
-                                   token: str, 
-                                   ) -> JSONResponse:
+
+async def send_reset_password_mail(
+    email: str,
+    token: str,
+) -> JSONResponse:
     """Envia o e-mail contendo token para redefinir a senha.
 
     Args:
@@ -59,7 +61,7 @@ async def send_reset_password_mail(email: str,
             subject="Recuperação de acesso",
             recipients=[email],
             body=body,
-            subtype=MessageType.html
+            subtype=MessageType.html,
         )
         fm = FastMail(conf)
         await fm.send_message(message)

--- a/src/models.py
+++ b/src/models.py
@@ -1,8 +1,6 @@
 """Definições dos modelos de dados da API que serão persistidos no
 banco pelo mapeamento objeto-relacional (ORM) do SQLAlchemy.
 """
-
-from datetime import datetime
 import enum
 from sqlalchemy import (
     Boolean,

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -6,7 +6,7 @@ Pydantic: https://docs.pydantic.dev/2.0/
 """
 
 from typing import List, Optional
-from datetime import date, datetime
+from datetime import date
 
 from pydantic import BaseModel, ConfigDict, Field, EmailStr
 from pydantic import model_validator, field_validator

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -281,16 +281,16 @@ class EntregaSchema(BaseModel):
         title="Percentual de progresso realizado",
         description=Entrega.percentual_progresso_realizado.comment,
     )
-    data_entrega: Optional[date] = Field(
+    data_entrega: date = Field(
         default=None, title="Data da entrega", description=Entrega.data_entrega.comment
     )
-    nome_demandante: Optional[str] = Field(
+    nome_demandante: str = Field(
         default=None,
         title="Nome do demandante",
         max_length=300,
         description=Entrega.nome_demandante.comment,
     )
-    nome_destinatario: Optional[str] = Field(
+    nome_destinatario: str = Field(
         default=None,
         title="Nome do destinatário",
         max_length=300,

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -424,7 +424,7 @@ class PlanoEntregasSchema(BaseModel):
         if any(
             entrega.data_entrega < self.data_inicio_plano_entregas
             or entrega.data_entrega > self.data_termino_plano_entregas
-            for entrega in self.entregas
+            for entrega in self.entregas if entrega.data_entrega is not None
         ):
             raise ValueError(
                 "Data de entrega precisa estar dentro do intervalo entre "

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -424,7 +424,8 @@ class PlanoEntregasSchema(BaseModel):
         if any(
             entrega.data_entrega < self.data_inicio_plano_entregas
             or entrega.data_entrega > self.data_termino_plano_entregas
-            for entrega in self.entregas if entrega.data_entrega is not None
+            for entrega in self.entregas
+            if entrega.data_entrega is not None
         ):
             raise ValueError(
                 "Data de entrega precisa estar dentro do intervalo entre "
@@ -522,12 +523,15 @@ class ListaStatusParticipanteSchema(BaseModel):
         description="Lista de Contribuições planejadas para o Plano de Trabalho.",
     )
 
+
 class Token(BaseModel):
     access_token: str
     token_type: str
 
+
 class TokenData(BaseModel):
     username: str | None = None
+
 
 class UsersInputSchema(BaseModel):
     __doc__ = Users.__doc__
@@ -536,6 +540,7 @@ class UsersInputSchema(BaseModel):
         title="e-mail do usuário",
         description=Users.email.comment,
     )
+
 
 class UsersGetSchema(UsersInputSchema):
     __doc__ = Users.__doc__
@@ -554,6 +559,7 @@ class UsersGetSchema(UsersInputSchema):
         title="Código SIAPE da organização que instituiu o PGD",
         description=Users.cod_SIAPE_instituidora.comment,
     )
+
 
 class UsersSchema(UsersGetSchema):
     password: str = Field(

--- a/src/util.py
+++ b/src/util.py
@@ -3,60 +3,6 @@
 import calendar
 from datetime import date, timedelta
 
-def sa_obj_to_dict(d: dict) -> dict:
-    "Copia os valores do objeto SQL Alchemy para um dicionário."
-    return {
-        k:
-            [
-                sa_obj_to_dict(item)
-                for item in v
-            ] if isinstance(v, list) and v else v
-        for k, v in d.__dict__.items()
-        if not k.startswith("_")
-    }
-
-def merge_dicts(d1: dict, d2:dict) -> dict:
-    "Atualiza d1 com os valores de d2."
-    # os que estão em d1, atualizar com d2
-    d = {
-        k: merge_dicts(v, d2.get(k, {})) \
-            if isinstance(v, dict) and v \
-            else d2.get(k, v)
-        for k, v in d1.items()
-    }
-    # os que estão em d2 mas não em d1, copiar de d2
-    d.update({
-        k: v
-        for k, v in d2.items()
-        if k not in d1.keys()
-    })
-    return d
-
-def list_to_dict(l: list, id_attr: str) -> dict:
-    "Transforma uma lista em dicionário, tomando o id como chave."
-    return {
-        entry.get(id_attr): {
-            key: value
-            for key, value in entry.items() if key != id_attr
-        }
-        for entry in l
-    }
-
-def dict_to_list(d: dict, id_attr: str) -> list:
-    "Transforma um dicionário em lista, tomando o id como chave."
-    return [
-        merge_dicts(
-            {
-                id_attr: item_id
-            },
-            {
-                key: value
-                for key, value in prop.items()
-            }
-        )
-        for item_id, prop in sorted(d.items())
-    ]
-
 
 def over_a_year(start: date, end: date) -> int:
     """Calculates wether or not the period from `start` to `end` comprises
@@ -75,8 +21,8 @@ def over_a_year(start: date, end: date) -> int:
         add_leap = add_leap + 1
     if calendar.isleap(end.year) and end.month > 3:
         add_leap = add_leap + 1
-    if end - start == timedelta(days=365+add_leap):
+    if end - start == timedelta(days=365 + add_leap):
         return 0
-    if end - start > timedelta(days=365+add_leap):
+    if end - start > timedelta(days=365 + add_leap):
         return 1
     return -1

--- a/tests/entrypoint_test.py
+++ b/tests/entrypoint_test.py
@@ -4,26 +4,25 @@ Testes relacionados com acessos aos endpoints.
 
 from httpx import Client
 from fastapi import status
-import pytest
+
 
 def test_redirect_to_docs_html(client: Client):
     """
     Testa se o acesso por um navegador na raiz redireciona para o /docs.
     """
-    response = client.get("/",
-        allow_redirects=False,
-        headers={"Accept": "text/html"})
+    response = client.get("/", allow_redirects=False, headers={"Accept": "text/html"})
 
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
-    assert response.headers['Location'] == "/docs"
+    assert response.headers["Location"] == "/docs"
+
 
 def test_redirect_to_entrypoint_json(client: Client):
     """
     Testa se o acesso por um script na raiz redireciona para o /openapi.json.
     """
-    response = client.get("/",
-        allow_redirects=False,
-        headers={"Accept": "application/json"})
+    response = client.get(
+        "/", allow_redirects=False, headers={"Accept": "application/json"}
+    )
 
     assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
-    assert response.headers['Location'] == "/openapi.json"
+    assert response.headers["Location"] == "/openapi.json"

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -169,7 +169,8 @@ def test_put_participante_omit_optional_fields(
             response_part[attribute] == partial_input_part[attribute]
             for attributes in fields_participantes["mandatory"]
             for attribute in attributes
-        ) for response_part in response.json()["lista_status"]
+        )
+        for response_part in response.json()["lista_status"]
     )
 
 

--- a/tests/plano_entregas_test.py
+++ b/tests/plano_entregas_test.py
@@ -193,6 +193,35 @@ def test_create_plano_entregas_entrega_omit_optional_fields(
     assert_equal_plano_entregas(response.json(), input_pe)
 
 
+@pytest.mark.parametrize("nulled_fields", enumerate(fields_entrega["optional"]))
+def test_create_plano_entregas_entrega_null_optional_fields(
+    truncate_pe,  # pylint: disable=unused-argument
+    input_pe: dict,
+    nulled_fields: list,
+    user1_credentials: dict,
+    header_usr_1: dict,
+    client: Client,
+):
+    """Tenta criar um novo plano de entregas com o valor null nos campos opcionais"""
+
+    offset, field_list = nulled_fields
+    for field in field_list:
+        for entrega in input_pe["entregas"]:
+            if field in entrega:
+                entrega[field] = None
+
+    input_pe["id_plano_entrega_unidade"] = 557 + offset
+    response = client.put(
+        f"/organizacao/{user1_credentials['cod_SIAPE_instituidora']}"
+        f"/plano_entregas/{input_pe['id_plano_entrega_unidade']}",
+        json=input_pe,
+        headers=header_usr_1,
+    )
+    print(response.json())
+    assert response.status_code == status.HTTP_201_CREATED
+    assert_equal_plano_entregas(response.json(), input_pe)
+
+
 @pytest.mark.parametrize(
     "missing_fields", enumerate(fields_plano_entregas["mandatory"])
 )

--- a/tests/plano_entregas_test.py
+++ b/tests/plano_entregas_test.py
@@ -14,7 +14,9 @@ from util import over_a_year
 
 fields_plano_entregas = {
     "optional": (
-        ["cancelado", "avaliacao_plano_entregas", "data_avaliacao_plano_entregas"],
+        ["cancelado"],
+        ["avaliacao_plano_entregas"],
+        ["data_avaliacao_plano_entregas"],
     ),
     "mandatory": (
         ["id_plano_entrega_unidade"],

--- a/tests/plano_trabalho_test.py
+++ b/tests/plano_trabalho_test.py
@@ -284,6 +284,35 @@ def test_create_plano_trabalho_contribuicao_omit_optional_fields(
     assert response.status_code == status.HTTP_201_CREATED
 
 
+@pytest.mark.parametrize("nulled_fields", enumerate(fields_contribuicao["optional"]))
+def test_create_plano_trabalho_contribuicao_null_optional_fields(
+    # fixture example_pe é necessária para cumprir IntegrityConstraint (FK)
+    truncate_pe,  # pylint: disable=unused-argument
+    example_pe,  # pylint: disable=unused-argument
+    input_pt: dict,
+    nulled_fields: list,
+    user1_credentials: dict,
+    header_usr_1: dict,
+    client: Client,
+):
+    """Tenta criar um novo plano de trabalho enviando null nos campos opcionais"""
+    partial_input_pt = input_pt.copy()
+    offset, field_list = nulled_fields
+    for field in field_list:
+        for contribuicao in partial_input_pt["contribuicoes"]:
+            if field in contribuicao:
+                contribuicao[field] = None
+
+    partial_input_pt["id_plano_trabalho_participante"] = 557 + offset
+    response = client.put(
+        f"/organizacao/{user1_credentials['cod_SIAPE_instituidora']}"
+        f"/plano_trabalho/{partial_input_pt['id_plano_trabalho_participante']}",
+        json=partial_input_pt,
+        headers=header_usr_1,
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 @pytest.mark.parametrize("omitted_fields", enumerate(fields_consolidacao["optional"]))
 def test_create_plano_trabalho_consolidacao_omit_optional_fields(
     # fixture example_pe é necessária para cumprir IntegrityConstraint (FK)
@@ -302,6 +331,35 @@ def test_create_plano_trabalho_consolidacao_omit_optional_fields(
         for consolidacao in partial_input_pt["consolidacoes"]:
             if field in consolidacao:
                 del consolidacao[field]
+
+    partial_input_pt["id_plano_trabalho_participante"] = 557 + offset
+    response = client.put(
+        f"/organizacao/{user1_credentials['cod_SIAPE_instituidora']}"
+        f"/plano_trabalho/{partial_input_pt['id_plano_trabalho_participante']}",
+        json=partial_input_pt,
+        headers=header_usr_1,
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+@pytest.mark.parametrize("nulled_fields", enumerate(fields_consolidacao["optional"]))
+def test_create_plano_trabalho_consolidacao_null_optional_fields(
+    # fixture example_pe é necessária para cumprir IntegrityConstraint (FK)
+    truncate_pe,  # pylint: disable=unused-argument
+    example_pe,  # pylint: disable=unused-argument
+    input_pt: dict,
+    nulled_fields: list,
+    user1_credentials: dict,
+    header_usr_1: dict,
+    client: Client,
+):
+    """Tenta criar um novo plano de trabalho enviando null nos campos opcionais"""
+    partial_input_pt = input_pt.copy()
+    offset, field_list = nulled_fields
+    for field in field_list:
+        for consolidacao in partial_input_pt["consolidacoes"]:
+            if field in consolidacao:
+                consolidacao[field] = None
 
     partial_input_pt["id_plano_trabalho_participante"] = 557 + offset
     response = client.put(

--- a/tests/plano_trabalho_test.py
+++ b/tests/plano_trabalho_test.py
@@ -255,6 +255,35 @@ def test_create_plano_trabalho_id_entrega_check(
         assert response.status_code == status.HTTP_201_CREATED
 
 
+@pytest.mark.parametrize("omitted_fields", enumerate(fields_contribuicao["optional"]))
+def test_create_plano_trabalho_contribuicao_omit_optional_fields(
+    # fixture example_pe é necessária para cumprir IntegrityConstraint (FK)
+    truncate_pe,  # pylint: disable=unused-argument
+    example_pe,  # pylint: disable=unused-argument
+    input_pt: dict,
+    omitted_fields: list,
+    user1_credentials: dict,
+    header_usr_1: dict,
+    client: Client,
+):
+    """Tenta criar um novo plano de trabalho omitindo campos opcionais"""
+    partial_input_pt = input_pt.copy()
+    offset, field_list = omitted_fields
+    for field in field_list:
+        for contribuicao in partial_input_pt["contribuicoes"]:
+            if field in contribuicao:
+                del contribuicao[field]
+
+    partial_input_pt["id_plano_trabalho_participante"] = 557 + offset
+    response = client.put(
+        f"/organizacao/{user1_credentials['cod_SIAPE_instituidora']}"
+        f"/plano_trabalho/{partial_input_pt['id_plano_trabalho_participante']}",
+        json=partial_input_pt,
+        headers=header_usr_1,
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
 @pytest.mark.parametrize("omitted_fields", enumerate(fields_consolidacao["optional"]))
 def test_create_plano_trabalho_consolidacao_omit_optional_fields(
     # fixture example_pe é necessária para cumprir IntegrityConstraint (FK)

--- a/tests/plano_trabalho_test.py
+++ b/tests/plano_trabalho_test.py
@@ -27,6 +27,10 @@ fields_plano_trabalho = {
 }
 
 fields_contribuicao = {
+    "optional": (
+        ["descricao_contribuicao"],
+        # ["id_entrega"], # obrigatório quando tipo_contribuicao==1
+    ),
     "mandatory": (
         ["id_plano_trabalho_participante"],
         ["tipo_contribuicao"],


### PR DESCRIPTION
According to requisites file defined by stakeholder, some fields were defined as mandatory.

In `models.py` they were indeed `nullable=False`, but in `schemas.py` they were defined as optional. We made it consistent by making it mandatory there too.

Some new tests were added for making sure that optional fields can be included with a json value of `null`.

Fixes #95