### PR TITLE
Refactor tests for Plano de Trabalho and Participante to use pytest classes

### DIFF
--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -98,7 +98,7 @@ class BaseParticipanteTest:
             BaseParticipanteTest.remove_null_optional_fields(participante_2.copy())
         )
 
-    def create_participante(
+    def put_participante(
         self,
         input_part: dict,
         cod_unidade_autorizadora: Optional[int] = None,
@@ -106,7 +106,7 @@ class BaseParticipanteTest:
         matricula_siape: Optional[str] = None,
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Criar um Participante.
+        """Cria ou atualiza um Participante pela API, usando o verbo PUT.
 
         Args:
             input_part (dict): O dicionário de entrada do Participante.
@@ -144,7 +144,7 @@ class BaseParticipanteTest:
         cod_unidade_lotacao: int,
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Obter um Participante.
+        """Obtém um Participante pela API, usando o verbo GET.
 
         Args:
             matricula_siape (str): A matrícula SIAPE do Participante.
@@ -173,7 +173,7 @@ class TestCreateParticipante(BaseParticipanteTest):
         """Cria um novo Participante, em uma unidade na qual o usuário
         está autorizado, contendo todos os dados necessários.
         """
-        response = self.create_participante(
+        response = self.put_participante(
             self.input_part,
         )
 
@@ -185,7 +185,7 @@ class TestCreateParticipante(BaseParticipanteTest):
         """Tenta submeter um participante em outra unidade autorizadora
         (user não é admin)
         """
-        response = self.create_participante(
+        response = self.put_participante(
             self.input_part,
             cod_unidade_autorizadora=3,  # unidade diferente
             header_usr=self.header_usr_2,
@@ -216,7 +216,7 @@ class TestCreateParticipante(BaseParticipanteTest):
         )
         assert admin_data.get("is_admin", None) is True
 
-        response = self.create_participante(
+        response = self.put_participante(
             self.input_part,
             header_usr=self.header_admin,
         )
@@ -239,7 +239,7 @@ class TestUpdateParticipante(BaseParticipanteTest):
         possui um Plano de Trabalho a ele associado.
         """
         input_part = self.input_part.copy()
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_200_OK
 
     def test_update_participante(
@@ -247,11 +247,11 @@ class TestUpdateParticipante(BaseParticipanteTest):
     ):
         """Atualiza um participante existente."""
         input_part = self.input_part.copy()
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_201_CREATED
 
         input_part["modalidade_execucao"] = 2
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["modalidade_execucao"] == 2
 
@@ -296,7 +296,7 @@ class TestUpdateParticipante(BaseParticipanteTest):
         input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_1
         input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_1
         input_part["matricula_siape"] = matricula_siape_1
-        response = self.create_participante(
+        response = self.put_participante(
             input_part,
             cod_unidade_autorizadora=cod_unidade_autorizadora_1,
             cod_unidade_lotacao=cod_unidade_lotacao_1,
@@ -318,7 +318,7 @@ class TestUpdateParticipante(BaseParticipanteTest):
         input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_2
         input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_2
         input_part["matricula_siape"] = matricula_siape_2
-        response = self.create_participante(
+        response = self.put_participante(
             input_part,
             cod_unidade_autorizadora=cod_unidade_autorizadora_2,
             cod_unidade_lotacao=cod_unidade_lotacao_2,
@@ -348,7 +348,7 @@ class TestCreateParticipanteInconsistentURLData(BaseParticipanteTest):
     ):
         """Tenta submeter participante inconsistente (URL difere do JSON)"""
         nova_matricula = "3311776"
-        response = self.create_participante(
+        response = self.put_participante(
             input_part=self.input_part,
             matricula_siape=nova_matricula,
         )
@@ -375,7 +375,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         """Tenta submeter um participante com matricula_siape inválida."""
         input_part = self.input_part.copy()
         input_part["matricula_siape"] = matricula_siape
-        response = self.create_participante(
+        response = self.put_participante(
             input_part,
             matricula_siape=input_part["matricula_siape"],
         )
@@ -411,7 +411,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         """Tenta submeter um participante com cpf inválido."""
         input_part = self.input_part.copy()
         input_part["cpf"] = cpf_participante
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         detail_messages = [
             "Dígitos verificadores do CPF inválidos.",
@@ -440,7 +440,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         input_part["matricula_siape"] = (
             f"{1800000 + offset}"  # precisa ser um novo participante
         )
-        response = self.create_participante(
+        response = self.put_participante(
             input_part,
             cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
             cod_unidade_lotacao=cod_unidade_lotacao,
@@ -460,7 +460,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         com valor inválido."""
         input_part = self.input_part.copy()
         input_part["situacao"] = situacao
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         detail_messages = "Valor do campo 'situacao' inválido; permitido: 0, 1"
         assert any(
@@ -476,7 +476,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         """Tenta submeter um participante com modalidade de execução inválida"""
         input_part = self.input_part.copy()
         input_part["modalidade_execucao"] = modalidade_execucao
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         detail_messages = "Modalidade de execução inválida; permitido: 1, 2, 3, 4, 5"
         assert any(
@@ -555,7 +555,7 @@ class TestCreateParticipanteDateValidation(BaseParticipanteTest):
         input_part["data_assinatura_tcr"] = (
             date.today() + timedelta(days=1)
         ).isoformat()
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
 
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         detail_messages = "Input should be in the past"
@@ -591,6 +591,6 @@ class TestCreateParticipanteDateValidation(BaseParticipanteTest):
             )
             - timedelta(days=1)
         ).isoformat()
-        response = self.create_participante(input_part)
+        response = self.put_participante(input_part)
 
         assert response.status_code == status.HTTP_201_CREATED

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -6,7 +6,7 @@ from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
 from fastapi import status
-from httpx import Client
+from httpx import Client, Response
 
 import pytest
 
@@ -26,579 +26,571 @@ FIELDS_PARTICIPANTES = {
     ),
 }
 
-
-# Helper functions
-
-
-def remove_null_optional_fields(data: dict) -> dict:
-    """Remove fields that are None from the data."""
-    if not isinstance(data, dict):
-        print(f"data: {data}")
-        print(f"type: {type(data)}")
-        raise ValueError("Data must be a dict")
-    for fields in FIELDS_PARTICIPANTES["optional"]:
-        for field in fields:
-            if field in data and data[field] is None:
-                del data[field]
-    return data
+# Classe base de testes
 
 
-def parse_datetimes(data: dict) -> dict:
-    """Parse datetimes from the data."""
-    if isinstance(data["data_assinatura_tcr"], str):
-        data["data_assinatura_tcr"] = datetime.fromisoformat(
-            data["data_assinatura_tcr"]
-        )
-    return data
+class BaseParticipanteTest:
+    """Classe base para testes de Participantes."""
 
-
-def assert_equal_participante(participante_1: dict, participante_2: dict):
-    """Verifica a igualdade de dois participantes, considerando
-    apenas os campos obrigatórios.
-    """
-    assert parse_datetimes(
-        remove_null_optional_fields(participante_1.copy())
-    ) == parse_datetimes(remove_null_optional_fields(participante_2.copy()))
-
-
-# Os testes usam muitas fixtures, então necessariamente precisam de
-# muitos argumentos. Além disso, algumas fixtures não retornam um valor
-# para ser usado no teste, mas mesmo assim são executadas quando estão
-# presentes como um argumento da função.
-# A linha abaixo desabilita os warnings do Pylint sobre isso.
-# pylint: disable=too-many-arguments
-
-
-def test_put_participante(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Testa a submissão de um participante a partir do template"""
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.json().get("detail", None) is None
-    assert_equal_participante(response.json(), input_part)
-
-
-def test_put_participante_unidade_nao_permitida(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    header_usr_2: dict,
-    client: Client,
-):
-    """
-    Testa a submissão de um participante em outra unidade autorizadora
-    (user não é admin)
-    """
-    response = client.put(
-        f"/organizacao/SIAPE/3/3/participante/{input_part['cpf']}",
-        json=input_part,
-        headers=header_usr_2,
-    )
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    detail_msg = "Usuário não tem permissão na cod_unidade_autorizadora informada"
-    assert response.json().get("detail", None) == detail_msg
-
-
-def test_put_participante_outra_unidade_admin(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    header_admin: dict,
-    admin_credentials: dict,
-    client: Client,
-):
-    """Testa, usando usuário admin, a submissão de um participante em outra
-    unidade autorizadora
-    """
-    input_part["cod_unidade_autorizadora"] = 3  # unidade diferente
-    input_part["cod_unidade_lotacao"] = 30  # unidade diferente
-
-    response = client.get(
-        f"/user/{admin_credentials['username']}",
-        headers=header_admin,
-    )
-
-    # Verifica se o usuário é admin e se está em outra unidade
-    assert response.status_code == status.HTTP_200_OK
-    admin_data = response.json()
-    assert (
-        admin_data.get("cod_unidade_autorizadora", None)
-        != input_part["cod_unidade_autorizadora"]
-    )
-    assert admin_data.get("is_admin", None) is True
-
-    response = client.put(
-        f"/organizacao/SIAPE/{input_part['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_admin,
-    )
-
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.json().get("detail", None) is None
-    assert_equal_participante(response.json(), input_part)
-
-
-@pytest.mark.parametrize(
-    (
-        "cod_unidade_autorizadora_1, cod_unidade_autorizadora_2, "
-        "cod_unidade_lotacao_1, cod_unidade_lotacao_2, "
-        "matricula_siape_1, matricula_siape_2"
-    ),
-    [
-        # mesmas unidades, mesma matrícula SIAPE
-        (1, 1, 10, 10, "1237654", "1237654"),
-        # unidades autorizadoras diferentes, mesma matrícula SIAPE
-        (1, 2, 10, 20, "1237654", "1237654"),
-        # unidades de lotação diferentes, mesma matrícula SIAPE
-        (1, 1, 10, 11, "1237654", "1237654"),
-        # mesma unidade, matrículas diferentes
-        (1, 1, 10, 10, "1237654", "1230054"),
-        # unidades diferentes, matrículas diferentes
-        (1, 2, 10, 20, "1237654", "1230054"),
-    ],
-)
-def test_put_duplicate_participante(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    cod_unidade_autorizadora_1: int,
-    cod_unidade_autorizadora_2: int,
-    cod_unidade_lotacao_1: int,
-    cod_unidade_lotacao_2: int,
-    matricula_siape_1: str,
-    matricula_siape_2: str,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    header_usr_2: dict,
-    client: Client,
-):
-    """
-    Testa o envio de um mesmo participantes com a mesma matrícula SIAPE.
-    O comportamento do segundo envio será testado conforme o caso.
-
-    Sendo a mesma matrícula na mesma unidade autorizadora e de lotação,
-    o registro será atualizado e retornará o código HTTP 200 Ok.
-    Se a unidade e/ou a matrícula forem diferentes, entende-se que será
-    criado um novo registro e será retornado o código HTTP 201 Created.
-    """
-    input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_1
-    input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_1
-    input_part["matricula_siape"] = matricula_siape_1
-    response = client.put(
-        f"/organizacao/SIAPE/{cod_unidade_autorizadora_1}"
-        f"/{cod_unidade_lotacao_1}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-    assert response.status_code == status.HTTP_201_CREATED
-    assert response.json().get("detail", None) is None
-    assert_equal_participante(response.json(), input_part)
-
-    if cod_unidade_autorizadora_2 == user1_credentials["cod_unidade_autorizadora"]:
-        header_usr = header_usr_1
-    else:
-        header_usr = header_usr_2
-    input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_2
-    input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_2
-    input_part["matricula_siape"] = matricula_siape_2
-    response = client.put(
-        f"/organizacao/SIAPE/{cod_unidade_autorizadora_2}"
-        f"/{cod_unidade_lotacao_2}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr,
-    )
-
-    if (
-        (cod_unidade_autorizadora_1 == cod_unidade_autorizadora_2)
-        and (cod_unidade_lotacao_1 == cod_unidade_lotacao_2)
-        and (matricula_siape_1 == matricula_siape_2)
+    # pylint: disable=too-many-arguments
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        truncate_participantes,  # pylint: disable=unused-argument
+        input_part: dict,
+        user1_credentials: dict,
+        header_usr_1: dict,
+        header_usr_2: dict,
+        header_admin: dict,
+        admin_credentials: dict,
+        client: Client,
     ):
-        assert response.status_code == status.HTTP_200_OK
-    else:
+        """Configurar o ambiente de teste.
+
+        Args:
+                Participantes.
+            input_part (dict): Dados usados para criar um Participante.
+            user1_credentials (dict): Credenciais do usuário 1.
+            header_usr_2 (dict): Cabeçalhos HTTP para o usuário 2.
+            header_admin (dict): Cabeçalhos HTTP para o usuário admin.
+            admin_credentials (dict): Credenciais do usuário admin.
+            client (Client): Uma instância do cliente HTTPX.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.input_part = input_part
+        self.user1_credentials = user1_credentials
+        self.header_usr_1 = header_usr_1
+        self.header_usr_2 = header_usr_2
+        self.header_admin = header_admin
+        self.admin_credentials = admin_credentials
+        self.client = client
+
+    @staticmethod
+    def parse_datetimes(data: dict) -> dict:
+        """Parse datetimes from the data."""
+        if isinstance(data["data_assinatura_tcr"], str):
+            data["data_assinatura_tcr"] = datetime.fromisoformat(
+                data["data_assinatura_tcr"]
+            )
+        return data
+
+    @staticmethod
+    def remove_null_optional_fields(data: dict) -> dict:
+        """Remove fields that are None from the data."""
+        if not isinstance(data, dict):
+            print(f"data: {data}")
+            print(f"type: {type(data)}")
+            raise ValueError("Data must be a dict")
+        for fields in FIELDS_PARTICIPANTES["optional"]:
+            for field in fields:
+                if field in data and data[field] is None:
+                    del data[field]
+        return data
+
+    @staticmethod
+    def assert_equal_participante(participante_1: dict, participante_2: dict):
+        """Verifica a igualdade de dois participantes, considerando
+        apenas os campos obrigatórios.
+        """
+        assert BaseParticipanteTest.parse_datetimes(
+            BaseParticipanteTest.remove_null_optional_fields(participante_1.copy())
+        ) == BaseParticipanteTest.parse_datetimes(
+            BaseParticipanteTest.remove_null_optional_fields(participante_2.copy())
+        )
+
+    def create_participante(
+        self,
+        input_part: dict,
+        cod_unidade_autorizadora: Optional[int] = None,
+        cod_unidade_lotacao: Optional[int] = None,
+        matricula_siape: Optional[str] = None,
+        header_usr: Optional[dict] = None,
+    ) -> Response:
+        """Criar um Participante.
+
+        Args:
+            input_part (dict): O dicionário de entrada do Participante.
+            cod_unidade_autorizadora (int): O ID da unidade autorizadora.
+            cod_unidade_lotacao (int): O ID da unidade de lotação.
+            matricula_siape (str): A matrícula SIAPE do Participante.
+            header_usr (dict): Cabeçalhos HTTP para o usuário.
+
+        Returns:
+            httpx.Response: A resposta da API.
+        """
+        if cod_unidade_autorizadora is None:
+            cod_unidade_autorizadora = input_part["cod_unidade_autorizadora"]
+        if cod_unidade_lotacao is None:
+            cod_unidade_lotacao = input_part["cod_unidade_lotacao"]
+        if matricula_siape is None:
+            matricula_siape = input_part["matricula_siape"]
+        if header_usr is None:
+            header_usr = self.header_usr_1
+
+        response = self.client.put(
+            (
+                f"/organizacao/SIAPE/{cod_unidade_autorizadora}"
+                f"/{cod_unidade_lotacao}/participante/{matricula_siape}"
+            ),
+            json=input_part,
+            headers=header_usr,
+        )
+        return response
+
+    def get_participante(
+        self,
+        matricula_siape: str,
+        cod_unidade_autorizadora: int,
+        cod_unidade_lotacao: int,
+        header_usr: Optional[dict] = None,
+    ) -> Response:
+        """Obter um Participante.
+
+        Args:
+            matricula_siape (str): A matrícula SIAPE do Participante.
+            cod_unidade_autorizadora (int): O ID da unidade autorizadora.
+            cod_unidade_lotacao (int): O ID da unidade de lotação.
+            header_usr (dict): Cabeçalhos HTTP para o usuário.
+
+        Returns:
+            httpx.Response: A resposta da API.
+        """
+        if header_usr is None:
+            header_usr = self.header_usr_1
+        response = self.client.get(
+            f"/organizacao/SIAPE/{cod_unidade_autorizadora}"
+            f"/{cod_unidade_lotacao}"
+            f"/participante/{matricula_siape}",
+            headers=header_usr,
+        )
+        return response
+
+
+class TestCreateParticipante(BaseParticipanteTest):
+    """Testes para criação de Participante."""
+
+    def test_create_participante_complete(self):
+        """Cria um novo Participante, em uma unidade na qual o usuário
+        está autorizado, contendo todos os dados necessários.
+        """
+        response = self.create_participante(
+            self.input_part,
+        )
+
         assert response.status_code == status.HTTP_201_CREATED
-    assert response.json().get("detail", None) is None
-    assert_equal_participante(response.json(), input_part)
+        assert response.json().get("detail", None) is None
+        self.assert_equal_participante(response.json(), self.input_part)
+
+    def test_create_participante_in_unauthorized_unit(self):
+        """Tenta submeter um participante em outra unidade autorizadora
+        (user não é admin)
+        """
+        response = self.create_participante(
+            self.input_part,
+            cod_unidade_autorizadora=3,  # unidade diferente
+            header_usr=self.header_usr_2,
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        detail_msg = "Usuário não tem permissão na cod_unidade_autorizadora informada"
+        assert response.json().get("detail", None) == detail_msg
+
+    def test_create_participante_in_other_unit_as_admin(self):
+        """Testa, usando usuário admin, a submissão de um participante em outra
+        unidade autorizadora
+        """
+        self.input_part["cod_unidade_autorizadora"] = 3  # unidade diferente
+        self.input_part["cod_unidade_lotacao"] = 30  # unidade diferente
+
+        response = self.client.get(
+            f"/user/{self.admin_credentials['username']}",
+            headers=self.header_admin,
+        )
+
+        # Verifica se o usuário é admin e se está em outra unidade
+        assert response.status_code == status.HTTP_200_OK
+        admin_data = response.json()
+        assert (
+            admin_data.get("cod_unidade_autorizadora", None)
+            != self.input_part["cod_unidade_autorizadora"]
+        )
+        assert admin_data.get("is_admin", None) is True
+
+        response = self.create_participante(
+            self.input_part,
+            header_usr=self.header_admin,
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json().get("detail", None) is None
+        self.assert_equal_participante(response.json(), self.input_part)
 
 
-def test_update_participante_with_existing_pt(
-    truncate_participantes,  # pylint: disable=unused-argument
-    example_part,  # pylint: disable=unused-argument
-    example_pt,  # pylint: disable=unused-argument
-    input_part: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Atualiza um participante existente, sendo que o participante já
-    possui um Plano de Trabalho a ele associado.
-    """
-    response = client.put(
-        f"/organizacao/{input_part['origem_unidade']}"
-        f"/{input_part['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
+class TestUpdateParticipante(BaseParticipanteTest):
+    """Testes para atualização de um Participante."""
+
+    def test_update_participante_with_existing_pt(
+        self,
+        # pylint: disable=unused-argument
+        example_part: dict,
+        example_pt: dict,
+    ):
+        """Atualiza um participante existente, sendo que o participante já
+        possui um Plano de Trabalho a ele associado.
+        """
+        input_part = self.input_part.copy()
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_200_OK
+
+    def test_update_participante(
+        self,
+    ):
+        """Atualiza um participante existente."""
+        input_part = self.input_part.copy()
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        input_part["modalidade_execucao"] = 2
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["modalidade_execucao"] == 2
+
+    @pytest.mark.parametrize(
+        (
+            "cod_unidade_autorizadora_1, cod_unidade_autorizadora_2, "
+            "cod_unidade_lotacao_1, cod_unidade_lotacao_2, "
+            "matricula_siape_1, matricula_siape_2"
+        ),
+        [
+            # mesmas unidades, mesma matrícula SIAPE
+            (1, 1, 10, 10, "1237654", "1237654"),
+            # unidades autorizadoras diferentes, mesma matrícula SIAPE
+            (1, 2, 10, 20, "1237654", "1237654"),
+            # unidades de lotação diferentes, mesma matrícula SIAPE
+            (1, 1, 10, 11, "1237654", "1237654"),
+            # mesma unidade, matrículas diferentes
+            (1, 1, 10, 10, "1237654", "1230054"),
+            # unidades diferentes, matrículas diferentes
+            (1, 2, 10, 20, "1237654", "1230054"),
+        ],
     )
-    assert response.status_code == status.HTTP_200_OK
+    def test_update_participante_duplicate_matricula(
+        self,
+        cod_unidade_autorizadora_1: int,
+        cod_unidade_autorizadora_2: int,
+        cod_unidade_lotacao_1: int,
+        cod_unidade_lotacao_2: int,
+        matricula_siape_1: str,
+        matricula_siape_2: str,
+    ):
+        """
+        Testa o envio de um mesmo participante com a mesma matrícula SIAPE.
+        O comportamento do segundo envio será testado conforme o caso.
+
+        Sendo a mesma matrícula na mesma unidade autorizadora e de lotação,
+        o registro será atualizado e retornará o código HTTP 200 Ok.
+        Se a unidade e/ou a matrícula forem diferentes, entende-se que será
+        criado um novo registro e será retornado o código HTTP 201 Created.
+        """
+        input_part = self.input_part.copy()
+        input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_1
+        input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_1
+        input_part["matricula_siape"] = matricula_siape_1
+        response = self.create_participante(
+            input_part,
+            cod_unidade_autorizadora=cod_unidade_autorizadora_1,
+            cod_unidade_lotacao=cod_unidade_lotacao_1,
+            matricula_siape=matricula_siape_1,
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        assert response.json().get("detail", None) is None
+        self.assert_equal_participante(response.json(), input_part)
+
+        # ajusta o header para que tenha permissão de escrever naquele
+        # cod_unidade_autorizadora
+        if (
+            cod_unidade_autorizadora_2
+            == self.user1_credentials["cod_unidade_autorizadora"]
+        ):
+            header_usr = self.header_usr_1
+        else:
+            header_usr = self.header_usr_2
+        input_part["cod_unidade_autorizadora"] = cod_unidade_autorizadora_2
+        input_part["cod_unidade_lotacao"] = cod_unidade_lotacao_2
+        input_part["matricula_siape"] = matricula_siape_2
+        response = self.create_participante(
+            input_part,
+            cod_unidade_autorizadora=cod_unidade_autorizadora_2,
+            cod_unidade_lotacao=cod_unidade_lotacao_2,
+            matricula_siape=matricula_siape_2,
+            header_usr=header_usr,
+        )
+
+        if (
+            (cod_unidade_autorizadora_1 == cod_unidade_autorizadora_2)
+            and (cod_unidade_lotacao_1 == cod_unidade_lotacao_2)
+            and (matricula_siape_1 == matricula_siape_2)
+        ):
+            # tudo é igual, está atualizando o mesmo participante
+            assert response.status_code == status.HTTP_200_OK
+        else:
+            # algo é diferente, está criando um novo participante
+            assert response.status_code == status.HTTP_201_CREATED
+        assert response.json().get("detail", None) is None
+        self.assert_equal_participante(response.json(), input_part)
 
 
-def test_create_participante_inconsistent(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta submeter participante inconsistente (URL difere do JSON)"""
-    nova_matricula = "3311776"
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{nova_matricula}",
-        json=input_part,
-        headers=header_usr_1,
+class TestCreateParticipanteInconsistentURLData(BaseParticipanteTest):
+    """Testa situações em que os dados da URL diferem do informado no JSON."""
+
+    def test_create_participante_inconsistent(
+        self,
+    ):
+        """Tenta submeter participante inconsistente (URL difere do JSON)"""
+        nova_matricula = "3311776"
+        response = self.create_participante(
+            input_part=self.input_part,
+            matricula_siape=nova_matricula,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_msg = "Parâmetro matricula_siape na URL e no JSON devem ser iguais"
+        assert response.json().get("detail", None) == detail_msg
+
+
+class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
+    """Testes para verificar as validações de campos do Participante."""
+
+    @pytest.mark.parametrize(
+        "matricula_siape",
+        [
+            ("12345678"),
+            ("0000000"),
+            ("9999999"),
+            ("123456"),
+            ("-123456"),
+            ("abcdefg"),
+        ],
     )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_msg = "Parâmetro matricula_siape na URL e no JSON devem ser iguais"
-    assert response.json().get("detail", None) == detail_msg
+    def test_create_participante_invalid_matricula_siape(self, matricula_siape: str):
+        """Tenta submeter um participante com matricula_siape inválida."""
+        input_part = self.input_part.copy()
+        input_part["matricula_siape"] = matricula_siape
+        response = self.create_participante(
+            input_part,
+            matricula_siape=input_part["matricula_siape"],
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_messages = [
+            "Matricula SIAPE deve ser numérica.",
+            "Matrícula SIAPE deve ter 7 dígitos.",
+            "Matricula SIAPE inválida.",
+        ]
+        received_error = response.json().get("detail")
+        if isinstance(received_error, str):
+            assert any(message in received_error for message in detail_messages)
+        else:
+            assert any(
+                f"Value error, {message}" in error["msg"]
+                for message in detail_messages
+                for error in received_error
+            )
 
-
-@pytest.mark.parametrize("missing_fields", enumerate(FIELDS_PARTICIPANTES["mandatory"]))
-def test_put_participante_missing_mandatory_fields(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    missing_fields: list,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta submeter participantes faltando campos obrigatórios"""
-    matricula_siape = input_part["matricula_siape"]
-    cod_unidade_lotacao = input_part["cod_unidade_lotacao"]
-    offset, field_list = missing_fields
-    for field in field_list:
-        del input_part[field]
-
-    input_part["matricula_siape"] = (
-        f"{1800000 + offset}"  # precisa ser um novo participante
+    @pytest.mark.parametrize(
+        "cpf_participante",
+        [
+            ("11111111111"),
+            ("22222222222"),
+            ("33333333333"),
+            ("44444444444"),
+            ("04811556435"),
+            ("444444444"),
+            ("4811556437"),
+        ],
     )
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{cod_unidade_lotacao}"
-        f"/participante/{matricula_siape}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-
-
-def test_get_participante(
-    truncate_participantes,  # pylint: disable=unused-argument
-    example_part,  # pylint: disable=unused-argument
-    header_usr_1: dict,
-    input_part: dict,
-    client: Client,
-):
-    """Tenta ler os dados de um participante pelo cpf."""
-    response = client.get(
-        f"/organizacao/SIAPE/{input_part['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        headers=header_usr_1,
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert_equal_participante(response.json(), input_part)
-
-
-def test_get_participante_inexistente(
-    user1_credentials: dict, header_usr_1: dict, client: Client
-):
-    """Tenta consultar um participante que não existe na base de dados."""
-    response = client.get(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        "/1"  # cod_unidade_lotacao
-        "/participante/3311776",
-        headers=header_usr_1,
-    )
-
-    assert response.status_code == status.HTTP_404_NOT_FOUND
-    assert response.json().get("detail", None) == "Participante não encontrado"
-
-
-def test_get_participante_different_unit(
-    truncate_participantes,  # pylint: disable=unused-argument
-    example_part_unidade_3,  # pylint: disable=unused-argument
-    input_part: dict,
-    header_usr_2: dict,
-    client: Client,
-):
-    """
-    Testa ler um participante em outra unidade autorizadora
-    (user não é admin)
-    """
-
-    input_part["cod_unidade_autorizadora"] = 3
-
-    response = client.get(
-        f"/organizacao/SIAPE/{input_part['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        headers=header_usr_2,
-    )
-
-    assert response.status_code == status.HTTP_403_FORBIDDEN
-    detail_msg = "Usuário não tem permissão na cod_unidade_autorizadora informada"
-    assert response.json().get("detail", None) == detail_msg
-
-
-def test_get_participante_different_unit_admin(
-    truncate_participantes,  # pylint: disable=unused-argument
-    example_part_unidade_3,  # pylint: disable=unused-argument
-    header_admin: dict,
-    input_part: dict,
-    client: Client,
-):
-    """Testa ler um participante em outra unidade autorizadora
-    (user é admin)"""
-
-    input_part["cod_unidade_autorizadora"] = 3
-
-    response = client.get(
-        f"/organizacao/{input_part['origem_unidade']}"
-        f"/{input_part['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        headers=header_admin,
-    )
-    assert response.status_code == status.HTTP_200_OK
-    assert_equal_participante(response.json(), input_part)
-
-
-@pytest.mark.parametrize(
-    "matricula_siape",
-    [
-        ("12345678"),
-        ("0000000"),
-        ("9999999"),
-        ("123456"),
-        ("-123456"),
-        ("abcdefg"),
-    ],
-)
-def test_put_participante_invalid_matricula_siape(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    matricula_siape: str,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta submeter um participante com matricula_siape inválida."""
-
-    input_part["matricula_siape"] = matricula_siape
-
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_messages = [
-        "Matricula SIAPE deve ser numérica.",
-        "Matrícula SIAPE deve ter 7 dígitos.",
-        "Matricula SIAPE inválida.",
-    ]
-    received_error = response.json().get("detail")
-    if isinstance(received_error, str):
-        assert any(message in received_error for message in detail_messages)
-    else:
+    def test_create_participante_invalid_cpf(self, cpf_participante: str):
+        """Tenta submeter um participante com cpf inválido."""
+        input_part = self.input_part.copy()
+        input_part["cpf"] = cpf_participante
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_messages = [
+            "Dígitos verificadores do CPF inválidos.",
+            "CPF inválido.",
+            "CPF precisa ter 11 dígitos.",
+            "CPF deve conter apenas dígitos.",
+        ]
         assert any(
             f"Value error, {message}" in error["msg"]
             for message in detail_messages
-            for error in received_error
+            for error in response.json().get("detail")
+        )
+
+    @pytest.mark.parametrize(
+        "missing_fields", enumerate(FIELDS_PARTICIPANTES["mandatory"])
+    )
+    def test_create_participante_missing_mandatory_fields(self, missing_fields: list):
+        """Tenta submeter participantes faltando campos obrigatórios"""
+        input_part = self.input_part.copy()
+        cod_unidade_lotacao = input_part["cod_unidade_lotacao"]
+        matricula_siape = input_part["matricula_siape"]
+        offset, field_list = missing_fields
+        for field in field_list:
+            del input_part[field]
+
+        input_part["matricula_siape"] = (
+            f"{1800000 + offset}"  # precisa ser um novo participante
+        )
+        response = self.create_participante(
+            input_part,
+            cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=cod_unidade_lotacao,
+            matricula_siape=matricula_siape,
+        )
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+    @pytest.mark.parametrize(
+        "situacao",
+        [
+            (3),
+            (-1),
+        ],
+    )
+    def test_create_participante_invalid_status(self, situacao: int):
+        """Tenta criar um participante com flag participante
+        com valor inválido."""
+        input_part = self.input_part.copy()
+        input_part["situacao"] = situacao
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_messages = "Valor do campo 'situacao' inválido; permitido: 0, 1"
+        assert any(
+            f"Value error, {message}" in error["msg"]
+            for message in detail_messages
+            for error in response.json().get("detail")
+        )
+
+    @pytest.mark.parametrize("modalidade_execucao", [(0), (-1), (6)])
+    def test_create_participante_invalid_modalidade_execucao(
+        self, modalidade_execucao: int
+    ):
+        """Tenta submeter um participante com modalidade de execução inválida"""
+        input_part = self.input_part.copy()
+        input_part["modalidade_execucao"] = modalidade_execucao
+        response = self.create_participante(input_part)
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_messages = "Modalidade de execução inválida; permitido: 1, 2, 3, 4, 5"
+        assert any(
+            f"Value error, {message}" in error["msg"]
+            for message in detail_messages
+            for error in response.json().get("detail")
         )
 
 
-@pytest.mark.parametrize(
-    "cpf_participante",
-    [
-        ("11111111111"),
-        ("22222222222"),
-        ("33333333333"),
-        ("44444444444"),
-        ("04811556435"),
-        ("444444444"),
-        ("4811556437"),
-    ],
-)
-def test_put_participante_invalid_cpf(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    cpf_participante: str,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta submeter um participante com cpf inválido."""
-    input_part["cpf"] = cpf_participante
+class TestGetParticipante(BaseParticipanteTest):
+    """Testes para a leitura de Participantes."""
 
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_messages = [
-        "Dígitos verificadores do CPF inválidos.",
-        "CPF inválido.",
-        "CPF precisa ter 11 dígitos.",
-        "CPF deve conter apenas dígitos.",
-    ]
-    assert any(
-        f"Value error, {message}" in error["msg"]
-        for message in detail_messages
-        for error in response.json().get("detail")
-    )
-
-
-@pytest.mark.parametrize(
-    "situacao",
-    [
-        (3),
-        (-1),
-    ],
-)
-def test_put_part_invalid_ativo(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    situacao: int,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta criar um participante com flag participante
-    com valor inválido."""
-    input_part["situacao"] = situacao
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_messages = "Valor do campo 'situacao' inválido; permitido: 0, 1"
-    assert any(
-        f"Value error, {message}" in error["msg"]
-        for message in detail_messages
-        for error in response.json().get("detail")
-    )
-
-
-@pytest.mark.parametrize("modalidade_execucao", [(0), (-1), (6)])
-def test_put_part_invalid_modalidade_execucao(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    modalidade_execucao: int,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta submeter um participante com modalidade de execução inválida"""
-    input_part["modalidade_execucao"] = modalidade_execucao
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_messages = "Modalidade de execução inválida; permitido: 1, 2, 3, 4, 5"
-    assert any(
-        f"Value error, {message}" in error["msg"]
-        for message in detail_messages
-        for error in response.json().get("detail")
-    )
-
-
-def test_put_invalid_data_assinatura_tcr(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    user1_credentials: dict,
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta criar um participante com data futura do TCR."""
-    # data de amanhã
-    input_part["data_assinatura_tcr"] = (date.today() + timedelta(days=1)).isoformat()
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
-
-    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-    detail_messages = "Input should be in the past"
-    assert any(
-        message in error["msg"]
-        for message in detail_messages
-        for error in response.json().get("detail")
-    )
-
-
-@pytest.mark.parametrize(
-    "timezone_utc",
-    [
-        -3,  # hora de Brasília
-        -5,  # horário de Rio Branco
-        None,  # sem fuso horário (timezone-naïve)
-    ],
-)
-def test_put_data_assinatura_tcr_timezone(
-    truncate_participantes,  # pylint: disable=unused-argument
-    input_part: dict,
-    user1_credentials: dict,
-    timezone_utc: Optional[int],
-    header_usr_1: dict,
-    client: Client,
-):
-    """Tenta criar um participante com data de assinatura do TCR em
-    diversos fuso-horários."""
-    input_part["data_assinatura_tcr"] = (
-        datetime.now(
-            **({"tz": timezone(timedelta(hours=timezone_utc))} if timezone_utc else {})
+    def test_get_participante(self, example_part):  # pylint: disable=unused-argument
+        """Tenta ler os dados de um participante pelo cpf."""
+        response = self.get_participante(
+            matricula_siape=self.input_part["matricula_siape"],
+            cod_unidade_autorizadora=self.input_part["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=self.input_part["cod_unidade_lotacao"],
         )
-        - timedelta(days=1)
-    ).isoformat()
-    response = client.put(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/{input_part['cod_unidade_lotacao']}"
-        f"/participante/{input_part['matricula_siape']}",
-        json=input_part,
-        headers=header_usr_1,
-    )
+        assert response.status_code == status.HTTP_200_OK
+        self.assert_equal_participante(response.json(), self.input_part)
 
-    assert response.status_code == status.HTTP_201_CREATED
+    def test_get_participante_not_found(self):
+        """Tenta consultar um participante que não existe na base de dados."""
+        response = self.get_participante(
+            matricula_siape=3311776,
+            cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=1,
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+        assert response.json().get("detail", None) == "Participante não encontrado"
+
+    def test_get_participante_in_different_unit(
+        self, example_part_unidade_3: dict  # pylint: disable=unused-argument
+    ):
+        """Testa ler um participante em outra unidade autorizadora
+        (usuário não é admin)"""
+        input_part = self.input_part.copy()
+        input_part["cod_unidade_autorizadora"] = 3
+
+        response = self.get_participante(
+            matricula_siape=input_part["matricula_siape"],
+            cod_unidade_autorizadora=input_part["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=input_part["cod_unidade_lotacao"],
+            header_usr=self.header_usr_2,
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        detail_msg = "Usuário não tem permissão na cod_unidade_autorizadora informada"
+        assert response.json().get("detail", None) == detail_msg
+
+    def test_get_participante_in_different_unit_as_admin(
+        self, example_part_unidade_3: dict  # pylint: disable=unused-argument
+    ):
+        """Testa ler um participante em outra unidade autorizadora
+        (usuário é admin)"""
+        input_part = self.input_part.copy()
+        input_part["cod_unidade_autorizadora"] = 3
+
+        response = self.get_participante(
+            matricula_siape=input_part["matricula_siape"],
+            cod_unidade_autorizadora=input_part["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=input_part["cod_unidade_lotacao"],
+            header_usr=self.header_admin,
+        )
+        assert response.status_code == status.HTTP_200_OK
+        self.assert_equal_participante(response.json(), input_part)
+
+
+class TestCreateParticipanteDateValidation(BaseParticipanteTest):
+    """Testes de validação de data durante a criação de um Participante."""
+
+    def test_create_participante_invalid_data_assinatura_tcr(self):
+        """Tenta criar um participante com data futura de assinatura do TCR."""
+        input_part = self.input_part.copy()
+        # data de amanhã
+        input_part["data_assinatura_tcr"] = (
+            date.today() + timedelta(days=1)
+        ).isoformat()
+        response = self.create_participante(input_part)
+
+        assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+        detail_messages = "Input should be in the past"
+        assert any(
+            message in error["msg"]
+            for message in detail_messages
+            for error in response.json().get("detail")
+        )
+
+    @pytest.mark.parametrize(
+        "timezone_utc",
+        [
+            None,  # sem fuso horário (timezone-naïve)
+            0,  # horário de Greenwich
+            -3,  # hora de Brasília
+            -5,  # horário de Rio Branco
+        ],
+    )
+    def test_create_participante_data_assinatura_tcr_timezone(
+        self, timezone_utc: Optional[int]
+    ):
+        """Tenta criar um participante com data de assinatura do TCR em
+        diversos fuso-horários (chamado "timezone-aware"), ou sem
+        definição de fuso-horário (chamado "timezone-naïve")."""
+        input_part = self.input_part.copy()
+        input_part["data_assinatura_tcr"] = (
+            datetime.now(  # horário de agora
+                **(
+                    {"tz": timezone(timedelta(hours=timezone_utc))}  # com tz
+                    if timezone_utc is not None
+                    else {}  # sem tz
+                )
+            )
+            - timedelta(days=1)
+        ).isoformat()
+        response = self.create_participante(input_part)
+
+        assert response.status_code == status.HTTP_201_CREATED

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -150,7 +150,7 @@ class BasePETest:
         )
         return response
 
-    def get_pe(
+    def get_plano_entregas(
         self,
         id_plano_entregas: str,
         cod_unidade_autorizadora: int,
@@ -212,7 +212,7 @@ class TestCreatePlanoEntrega(BasePETest):
         assert response.json()["data_avaliacao"] == "2023-08-15"
 
         # Consulta API para conferir se a alteração foi persistida
-        response = self.get_pe(
+        response = self.get_plano_entregas(
             input_pe["id_plano_entregas"],
             self.user1_credentials["cod_unidade_autorizadora"],
         )
@@ -562,7 +562,7 @@ class TestGetPlanoEntregas(BasePETest):
     ):
         """Tenta buscar um plano de entregas existente"""
 
-        response = self.get_pe(
+        response = self.get_plano_entregas(
             self.input_pe["id_plano_entregas"],
             self.user1_credentials["cod_unidade_autorizadora"],
         )
@@ -572,7 +572,7 @@ class TestGetPlanoEntregas(BasePETest):
     def test_get_pe_inexistente(self):
         """Tenta buscar um plano de entregas inexistente"""
 
-        response = self.get_pe(
+        response = self.get_plano_entregas(
             "888888888",
             self.user1_credentials["cod_unidade_autorizadora"],
         )

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -9,7 +9,7 @@ from fastapi import status as http_status
 
 import pytest
 
-from util import over_a_year, assert_error_message
+from util import assert_error_message
 
 # constantes
 

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -570,10 +570,15 @@ class TestGetPlanoEntregas(BasePETest):
 
     def test_get_plano_entregas(
         self,
-        truncate_pe,  # pylint: disable=unused-argument
-        example_pe,  # pylint: disable=unused-argument
+        # pylint: disable=unused-argument
+        truncate_pe,  # limpa a base de Planos de Entregas
+        example_pe,  # cria um Plano de Entregas de exemplo
     ):
-        """Tenta buscar um plano de entregas existente"""
+        """Testa a busca de um Plano de Entregas existente.
+
+        Verifica se a API retorna um status 200 OK e se o Plano de Entregas
+        retornado é igual ao Plano de Entregas criado.
+        """
 
         response = self.get_plano_entregas(
             self.input_pe["id_plano_entregas"],
@@ -583,7 +588,11 @@ class TestGetPlanoEntregas(BasePETest):
         self.assert_equal_plano_entregas(response.json(), self.input_pe)
 
     def test_get_pe_inexistente(self):
-        """Tenta buscar um plano de entregas inexistente"""
+        """Testa a busca de um Plano de Entregas inexistente.
+
+        Verifica se a API retorna um status 404 Not Found e a mensagem
+        de erro "Plano de entregas não encontrado".
+        """
 
         response = self.get_plano_entregas(
             "888888888",
@@ -612,7 +621,14 @@ class TestCreatePEDuplicateData(BasePETest):
         id_entrega_1: str,
         id_entrega_2: str,
     ):
-        """Tenta criar um plano de entregas com entregas com id_entrega duplicados"""
+        """Testa a criação de um Plano de Entregas com entregas duplicadas.
+
+        Verifica se:
+        - a API retorna um erro 422 Unprocessable Entity quando as entregas
+          possuem o mesmo id_entrega; e
+        - se retorna um status 201 Created quando as entregas possuem ids
+          diferentes.
+        """
 
         input_pe = self.input_pe.copy()
         input_pe["id_plano_entregas"] = id_plano_entregas
@@ -633,12 +649,18 @@ class TestCreatePEDuplicateData(BasePETest):
     def test_create_pe_duplicate_id_plano(
         self,
         truncate_pe,  # pylint: disable=unused-argument
-        input_pe: dict,
     ):
-        """Tenta criar um plano de entregas duplicado. O envio do mesmo
-        plano de entregas pela segunda vez deve substituir o primeiro.
+        """Testa o envio, mais de uma vez, de Planos de Entregas com o
+        mesmo id_plano_entregas.
+
+        Verifica se a API:
+        - retorna um status 201 Created quando o Plano de Entregas é criado
+          pela primeira vez; e
+        - um status 200 OK quando o mesmo Plano de Entregas é enviado
+          novamente, substituindo o anterior.
         """
 
+        input_pe = self.input_pe.copy()
         response = self.create_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
 
@@ -650,14 +672,18 @@ class TestCreatePEDuplicateData(BasePETest):
     def test_create_pe_same_id_plano_different_instituidora(
         self,
         truncate_pe,  # pylint: disable=unused-argument
-        input_pe: dict,
         user2_credentials: dict,
         header_usr_2: dict,
     ):
-        """Tenta criar um plano de entregas duplicado. O envio do mesmo
-        plano de entregas pela segunda vez deve substituir o primeiro.
+        """Testa a criação de Planos de Entregas com o mesmo
+        id_plano_entregas, mas com diferentes unidades autorizadoras.
+
+        Uma vez que tratam-se de unidades autorizadoras diferentes, a API
+        deve considerá-los como Planos de Entrega diferentes. Por isso,
+        deve retornar o status 201 Created em ambos os casos.
         """
 
+        input_pe = self.input_pe.copy()
         response = self.create_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
 

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -392,38 +392,33 @@ class TestCreatePEInputValidation(BasePETest):
         assert response.json().get("detail", None) == detail_msg
 
 
-def test_get_plano_entregas(
-    truncate_pe,  # pylint: disable=unused-argument
-    example_pe,  # pylint: disable=unused-argument
-    user1_credentials: dict,
-    header_usr_1: dict,
-    input_pe,
-    client: Client,
-):
-    """Tenta buscar um plano de entregas existente"""
+class TestGetPlanoEntregas(BasePETest):
+    """Testes para a busca de Planos de Entregas."""
 
-    response = client.get(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        f"/plano_entregas/{input_pe['id_plano_entregas']}",
-        headers=header_usr_1,
-    )
-    assert response.status_code == http_status.HTTP_200_OK
-    BasePETest.assert_equal_plano_entregas(response.json(), input_pe)
+    def test_get_plano_entregas(
+        self,
+        truncate_pe,  # pylint: disable=unused-argument
+        example_pe,  # pylint: disable=unused-argument
+        input_pe,
+    ):
+        """Tenta buscar um plano de entregas existente"""
 
+        response = self.get_pe(
+            input_pe["id_plano_entregas"],
+            self.user1_credentials["cod_unidade_autorizadora"],
+        )
+        assert response.status_code == http_status.HTTP_200_OK
+        self.assert_equal_plano_entregas(response.json(), input_pe)
 
-def test_get_pe_inexistente(
-    user1_credentials: dict, header_usr_1: dict, client: Client
-):
-    """Tenta buscar um plano de entregas inexistente"""
+    def test_get_pe_inexistente(self):
+        """Tenta buscar um plano de entregas inexistente"""
 
-    response = client.get(
-        f"/organizacao/SIAPE/{user1_credentials['cod_unidade_autorizadora']}"
-        "/plano_entregas/888888888",
-        headers=header_usr_1,
-    )
-    assert response.status_code == http_status.HTTP_404_NOT_FOUND
-
-    assert response.json().get("detail", None) == "Plano de entregas não encontrado"
+        response = self.get_pe(
+            "888888888",
+            self.user1_credentials["cod_unidade_autorizadora"],
+        )
+        assert response.status_code == http_status.HTTP_404_NOT_FOUND
+        assert response.json().get("detail", None) == "Plano de entregas não encontrado"
 
 
 @pytest.mark.parametrize(

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -109,7 +109,7 @@ class BasePETest:
             for id_entrega, entrega in second_plan_by_entrega.items()
         )
 
-    def create_plano_entregas(
+    def put_plano_entregas(
         self,
         input_pe: dict,
         id_plano_entregas: Optional[str] = None,
@@ -117,7 +117,8 @@ class BasePETest:
         cod_unidade_autorizadora: Optional[int] = None,
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Criar um Plano de Entregas.
+        """Cria ou atualiza um Plano de Entregas pela API, usando o método
+        PUT.
 
         Args:
             input_pe (dict): O dicionário de entrada do Plano de Entregas.
@@ -157,7 +158,7 @@ class BasePETest:
         origem_unidade: Optional[str] = "SIAPE",
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Obter um Plano de Entregas.
+        """Obtém um Plano de Entregas pela API, usando o verbo GET.
 
         Args:
             id_plano_entregas (str): O ID do Plano de Entregas.
@@ -199,7 +200,7 @@ class TestCreatePlanoEntrega(BasePETest):
         Plano de Entregas criado é igual ao Plano de Entregas enviado na requisição.
         """
 
-        response = self.create_plano_entregas(self.input_pe)
+        response = self.put_plano_entregas(self.input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
         assert response.json().get("detail", None) is None
         self.assert_equal_plano_entregas(response.json(), self.input_pe)
@@ -213,7 +214,7 @@ class TestCreatePlanoEntrega(BasePETest):
         input_pe = self.input_pe.copy()
         input_pe["avaliacao"] = 3
         input_pe["data_avaliacao"] = "2023-08-15"
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_200_OK
         assert response.json()["avaliacao"] == 3
         assert response.json()["data_avaliacao"] == "2023-08-15"
@@ -243,7 +244,7 @@ class TestCreatePlanoEntrega(BasePETest):
                     del entrega[field]
 
         input_pe["id_plano_entregas"] = str(557 + offset)
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
         self.assert_equal_plano_entregas(response.json(), input_pe)
 
@@ -263,7 +264,7 @@ class TestCreatePlanoEntrega(BasePETest):
                     entrega[field] = None
 
         input_pe["id_plano_entregas"] = str(557 + offset)
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
         self.assert_equal_plano_entregas(response.json(), input_pe)
 
@@ -297,7 +298,7 @@ class TestCreatePlanoEntrega(BasePETest):
             del input_pe[field]
 
         # Act
-        response = self.create_plano_entregas(input_pe, **placeholder_fields)
+        response = self.put_plano_entregas(input_pe, **placeholder_fields)
 
         # Assert
         assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -329,7 +330,7 @@ class TestCreatePlanoEntrega(BasePETest):
         for id_entrega in range(200):
             input_pe["entregas"].append(create_huge_entrega(id_entrega))
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
         self.assert_equal_plano_entregas(response.json(), input_pe)
 
@@ -380,7 +381,7 @@ class TestCreatePEInputValidation(BasePETest):
             "nome_unidade_destinataria"
         ] = nome_unidade_destinataria  # 300 caracteres
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if any(
             len(campo) > STR_MAX_SIZE
@@ -404,7 +405,7 @@ class TestCreatePEInputValidation(BasePETest):
 
         input_pe = self.input_pe.copy()
         input_pe["id_plano_entregas"] = "110"
-        response = self.create_plano_entregas(
+        response = self.put_plano_entregas(
             input_pe, id_plano_entregas="111"  # diferente de 110
         )
         assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -420,7 +421,7 @@ class TestCreatePEInputValidation(BasePETest):
         input_pe = self.input_pe.copy()
         original_input_pe = input_pe.copy()
         input_pe["cod_unidade_autorizadora"] = 999  # era 1
-        response = self.create_plano_entregas(
+        response = self.put_plano_entregas(
             input_pe,
             cod_unidade_autorizadora=original_input_pe["cod_unidade_autorizadora"],
             id_plano_entregas=original_input_pe["id_plano_entregas"],
@@ -445,7 +446,7 @@ class TestCreatePEInputValidation(BasePETest):
         input_pe = self.input_pe.copy()
         input_pe["cod_unidade_executora"] = cod_unidade_executora
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if cod_unidade_executora > 0:
             assert response.status_code == http_status.HTTP_201_CREATED
@@ -482,7 +483,7 @@ class TestCreatePEInputValidation(BasePETest):
         input_pe["entregas"][1]["meta_entrega"] = meta_entrega
         input_pe["entregas"][1]["tipo_meta"] = tipo_meta
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if tipo_meta == "percentual" and (meta_entrega < 0 or meta_entrega > 100):
             assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -515,7 +516,7 @@ class TestCreatePEInputValidation(BasePETest):
         input_pe = self.input_pe.copy()
         input_pe["entregas"][0]["tipo_meta"] = tipo_meta
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if tipo_meta in ("unidade", "percentual"):
             assert response.status_code == http_status.HTTP_201_CREATED
@@ -537,7 +538,7 @@ class TestCreatePEInputValidation(BasePETest):
 
         input_pe = self.input_pe.copy()
         input_pe["avaliacao"] = avaliacao
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if avaliacao in range(1, 6):
             assert response.status_code == http_status.HTTP_201_CREATED
@@ -580,7 +581,7 @@ class TestCreatePEInputValidation(BasePETest):
         input_pe["data_avaliacao"] = data_avaliacao
         input_pe["id_plano_entregas"] = id_plano_entregas
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if status == 5 and not (avaliacao and data_avaliacao):
             assert response.status_code == 422
@@ -663,7 +664,7 @@ class TestCreatePEDuplicateData(BasePETest):
         input_pe["entregas"][0]["id_entrega"] = id_entrega_1
         input_pe["entregas"][1]["id_entrega"] = id_entrega_2
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         if id_entrega_1 == id_entrega_2:
             assert response.status_code == 422
             detail_message = "Entregas devem possuir id_entrega diferentes"
@@ -689,10 +690,10 @@ class TestCreatePEDuplicateData(BasePETest):
         """
 
         input_pe = self.input_pe.copy()
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_200_OK
         assert response.json().get("detail", None) is None
         self.assert_equal_plano_entregas(response.json(), input_pe)
@@ -712,13 +713,13 @@ class TestCreatePEDuplicateData(BasePETest):
         """
 
         input_pe = self.input_pe.copy()
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
 
         input_pe["cod_unidade_autorizadora"] = user2_credentials[
             "cod_unidade_autorizadora"
         ]
-        response = self.create_plano_entregas(
+        response = self.put_plano_entregas(
             input_pe,
             cod_unidade_autorizadora=user2_credentials["cod_unidade_autorizadora"],
             header_usr=header_usr_2,

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -193,6 +193,7 @@ class TestCreatePlanoEntrega(BasePETest):
 
     def test_create_plano_entregas_completo(self):
         """Tenta criar um novo Plano de Entregas."""
+
         response = self.create_plano_entregas(self.input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
         assert response.json().get("detail", None) is None
@@ -203,6 +204,7 @@ class TestCreatePlanoEntrega(BasePETest):
         A fixture example_pe cria um novo Plano de Entregas na API.
         O teste altera um campo do PE e reenvia pra API (update).
         """
+
         input_pe = self.input_pe.copy()
         input_pe["avaliacao"] = 3
         input_pe["data_avaliacao"] = "2023-08-15"
@@ -223,6 +225,7 @@ class TestCreatePlanoEntrega(BasePETest):
     @pytest.mark.parametrize("omitted_fields", enumerate(FIELDS_ENTREGA["optional"]))
     def test_create_plano_entregas_entrega_omit_optional_fields(self, omitted_fields):
         """Tenta criar um novo Plano de Entregas omitindo campos opcionais."""
+
         input_pe = self.input_pe.copy()
         offset, field_list = omitted_fields
         for field in field_list:
@@ -238,6 +241,7 @@ class TestCreatePlanoEntrega(BasePETest):
     @pytest.mark.parametrize("nulled_fields", enumerate(FIELDS_ENTREGA["optional"]))
     def test_create_plano_entregas_entrega_null_optional_fields(self, nulled_fields):
         """Tenta criar um novo Plano de Entregas com o valor null nos campos opcionais."""
+
         input_pe = self.input_pe.copy()
         offset, field_list = nulled_fields
         for field in field_list:
@@ -258,6 +262,7 @@ class TestCreatePlanoEntrega(BasePETest):
         Na atualização com PUT, ainda assim é necessário informar todos os
         campos obrigatórios, uma vez que o conteúdo será substituído.
         """
+
         offset, field_list = missing_fields
         input_pe = self.input_pe.copy()
         # define um id_plano_entregas diferente para cada teste
@@ -336,6 +341,7 @@ class TestCreatePEInputValidation(BasePETest):
         """Testa a criação de um plano de entregas excedendo o tamanho
         máximo de cada campo.
         """
+
         input_pe = self.input_pe.copy()
         input_pe["id_plano_entregas"] = id_plano_entregas
         input_pe["entregas"][0]["nome_entrega"] = nome_entrega  # 300 caracteres
@@ -367,6 +373,7 @@ class TestCreatePEInputValidation(BasePETest):
         truncate_pe,  # pylint: disable=unused-argument
     ):
         """Tenta criar um plano de entregas com código de plano divergente"""
+
         input_pe = self.input_pe.copy()
         input_pe["id_plano_entregas"] = "110"
         response = self.create_plano_entregas(
@@ -381,6 +388,7 @@ class TestCreatePEInputValidation(BasePETest):
         truncate_pe,  # pylint: disable=unused-argument
     ):
         """Tenta criar um plano de entregas com código de unidade divergente"""
+
         input_pe = self.input_pe.copy()
         original_input_pe = input_pe.copy()
         input_pe["cod_unidade_autorizadora"] = 999  # era 1
@@ -405,6 +413,7 @@ class TestCreatePEInputValidation(BasePETest):
         Por ora não será feita validação no sistema, e sim apenas uma
         verificação de sanidade.
         """
+
         input_pe = self.input_pe.copy()
         input_pe["cod_unidade_executora"] = cod_unidade_executora
 
@@ -439,6 +448,7 @@ class TestCreatePEInputValidation(BasePETest):
         tipo_meta: str,
     ):
         """Tenta criar um Plano de Entregas com entrega com percentuais inválidos"""
+
         input_pe = self.input_pe.copy()
         input_pe["id_plano_entregas"] = id_plano_entregas
         input_pe["entregas"][1]["meta_entrega"] = meta_entrega
@@ -473,6 +483,7 @@ class TestCreatePEInputValidation(BasePETest):
         tipo_meta: str,
     ):
         """Tenta criar um Plano de Entregas com tipo de meta inválido"""
+
         input_pe = self.input_pe.copy()
         input_pe["entregas"][0]["tipo_meta"] = tipo_meta
 
@@ -495,6 +506,7 @@ class TestCreatePEInputValidation(BasePETest):
         avaliacao: int,
     ):
         """Tenta criar um Plano de Entregas com nota de avaliação inválida"""
+
         input_pe = self.input_pe.copy()
         input_pe["avaliacao"] = avaliacao
         response = self.create_plano_entregas(input_pe)
@@ -533,6 +545,7 @@ class TestCreatePEInputValidation(BasePETest):
         O status 5 só poderá ser usado se os campos "avaliacao" e "data_avaliacao"
         estiverem preenchidos.
         """
+
         input_pe = self.input_pe.copy()
         input_pe["status"] = status
         input_pe["avaliacao"] = avaliacao

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -192,7 +192,12 @@ class TestCreatePlanoEntrega(BasePETest):
     """Testes para a criação de um novo Plano de Entregas."""
 
     def test_create_plano_entregas_completo(self):
-        """Tenta criar um novo Plano de Entregas."""
+        """Testa a criação de um Plano de Entregas completo.
+
+        Verifica se a API retorna um status 201 Created quando um novo Plano de Entregas
+        é criado com sucesso, se a resposta não contém uma mensagem de erro e se o
+        Plano de Entregas criado é igual ao Plano de Entregas enviado na requisição.
+        """
 
         response = self.create_plano_entregas(self.input_pe)
         assert response.status_code == http_status.HTTP_201_CREATED
@@ -201,7 +206,7 @@ class TestCreatePlanoEntrega(BasePETest):
 
     def test_update_plano_entregas(self, example_pe):  # pylint: disable=unused-argument
         """Tenta criar um novo Plano de Entregas e atualizar alguns campos.
-        A fixture example_pe cria um novo Plano de Entregas na API.
+        A fixture example_pe cria um Plano de Entregas de exemplo usando a API.
         O teste altera um campo do PE e reenvia pra API (update).
         """
 
@@ -224,7 +229,11 @@ class TestCreatePlanoEntrega(BasePETest):
 
     @pytest.mark.parametrize("omitted_fields", enumerate(FIELDS_ENTREGA["optional"]))
     def test_create_plano_entregas_entrega_omit_optional_fields(self, omitted_fields):
-        """Tenta criar um novo Plano de Entregas omitindo campos opcionais."""
+        """Tenta criar um novo Plano de Entregas omitindo campos opcionais.
+
+        Verifica se a API retorna um status 201 Created, o que indica ter sido
+        criado com sucesso.
+        """
 
         input_pe = self.input_pe.copy()
         offset, field_list = omitted_fields
@@ -240,7 +249,11 @@ class TestCreatePlanoEntrega(BasePETest):
 
     @pytest.mark.parametrize("nulled_fields", enumerate(FIELDS_ENTREGA["optional"]))
     def test_create_plano_entregas_entrega_null_optional_fields(self, nulled_fields):
-        """Tenta criar um novo Plano de Entregas com o valor null nos campos opcionais."""
+        """Tenta criar um novo Plano de Entregas, preenchendo com o valor null
+        os campos opcionais.
+
+        Verifica se a API retorna um status 201 Created, o que indica ter sido
+        criado com sucesso."""
 
         input_pe = self.input_pe.copy()
         offset, field_list = nulled_fields
@@ -261,6 +274,9 @@ class TestCreatePlanoEntrega(BasePETest):
         """Tenta criar um Plano de Entregas, faltando campos obrigatórios.
         Na atualização com PUT, ainda assim é necessário informar todos os
         campos obrigatórios, uma vez que o conteúdo será substituído.
+
+        Verifica se a API retorna um status 422 Unprocessable Entity, o que
+        indica que a entrada foi rejeitada, conforme o esperado.
         """
 
         offset, field_list = missing_fields
@@ -287,10 +303,22 @@ class TestCreatePlanoEntrega(BasePETest):
         assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
 
     def test_create_huge_plano_entregas(self):
-        """Testa a criação de um Plano de Entregas com grande volume de dados."""
+        """Testa a criação de um Plano de Entregas com grande volume de dados.
+        Os campos que aceitam entrada livre de texto são preenchidos com textos
+        longos.
+        """
+
         input_pe = self.input_pe.copy()
 
-        def create_huge_entrega(id_entrega: int):
+        def create_huge_entrega(id_entrega: int) -> dict:
+            """Cria uma Entrega que ocupa bastante espaço de dados.
+
+            Args:
+                id_entrega (int): o id da Entrega.
+
+            Returns:
+                dict: os dados da Entrega.
+            """
             new_entrega = input_pe["entregas"][0].copy()
             new_entrega["id_entrega"] = str(3 + id_entrega)
             new_entrega["nome_entrega"] = "x" * 300  # 300 caracteres

--- a/tests/plano_entregas/date_validation_test.py
+++ b/tests/plano_entregas/date_validation_test.py
@@ -4,7 +4,6 @@ Entregas.
 
 from datetime import date
 
-from httpx import Client
 from fastapi import status as http_status
 
 import pytest

--- a/tests/plano_entregas/date_validation_test.py
+++ b/tests/plano_entregas/date_validation_test.py
@@ -10,7 +10,7 @@ from fastapi import status as http_status
 import pytest
 
 from util import over_a_year
-from .core_test import assert_equal_plano_entregas
+from .core_test import BasePETest
 
 
 # Datas básicas
@@ -59,7 +59,7 @@ def test_create_plano_entregas_date_interval_over_a_year(
         )
     else:
         assert response.status_code == http_status.HTTP_201_CREATED
-        assert_equal_plano_entregas(response.json(), input_pe)
+        BasePETest.assert_equal_plano_entregas(response.json(), input_pe)
 
 
 @pytest.mark.parametrize(
@@ -257,7 +257,7 @@ def test_create_plano_entregas_overlapping_date_interval(
     ):
         # um dos planos está cancelado, pode ser criado
         assert response.status_code == http_status.HTTP_201_CREATED
-        assert_equal_plano_entregas(response.json(), input_pe)
+        BasePETest.assert_equal_plano_entregas(response.json(), input_pe)
     else:
         if any(
             (
@@ -279,4 +279,4 @@ def test_create_plano_entregas_overlapping_date_interval(
         else:
             # não há sobreposição de datas
             assert response.status_code == http_status.HTTP_201_CREATED
-            assert_equal_plano_entregas(response.json(), input_pe)
+            BasePETest.assert_equal_plano_entregas(response.json(), input_pe)

--- a/tests/plano_entregas/date_validation_test.py
+++ b/tests/plano_entregas/date_validation_test.py
@@ -38,7 +38,7 @@ class TestPlanoDeDatasBasicas(BasePETest):
         input_pe["data_inicio"] = data_inicio
         input_pe["data_termino"] = data_termino
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if (
             over_a_year(
@@ -76,7 +76,7 @@ class TestPlanoDeDatasBasicas(BasePETest):
         input_pe["data_inicio"] = data_inicio
         input_pe["data_termino"] = data_termino
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         if data_inicio > data_termino:
             assert response.status_code == 422
             detail_message = "data_termino deve ser maior ou igual que data_inicio."
@@ -109,7 +109,7 @@ class TestPlanoDeDatasBasicas(BasePETest):
         input_pe["data_avaliacao"] = data_avaliacao
         input_pe["id_plano_entregas"] = id_plano_entregas
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
 
         if data_avaliacao < data_inicio:
             assert response.status_code == 422
@@ -156,7 +156,7 @@ class TestPlanoDeDatasEntregas(BasePETest):
         for entrega in input_pe["entregas"]:
             entrega["data_entrega"] = data_entrega
 
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         # Aceitar em todos os casos
         assert response.status_code == http_status.HTTP_201_CREATED
 
@@ -198,7 +198,7 @@ class TestPlanoDeDatasEntregas(BasePETest):
         input_pe2["data_termino"] = "2023-12-31"
         for entrega in input_pe2["entregas"]:
             entrega["data_entrega"] = "2023-12-31"
-        response = self.create_plano_entregas(
+        response = self.put_plano_entregas(
             input_pe2,
             cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
             id_plano_entregas=input_pe2["id_plano_entregas"],
@@ -215,7 +215,7 @@ class TestPlanoDeDatasEntregas(BasePETest):
             entrega["data_entrega"] = data_termino
         input_pe["avaliacao"] = None
         input_pe["data_avaliacao"] = None
-        response = self.create_plano_entregas(input_pe)
+        response = self.put_plano_entregas(input_pe)
         if (
             # se algum dos planos estiver cancelado, não há problema em haver
             # sobreposição

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -7,7 +7,7 @@ from fastapi import status as http_status
 from .core_test import BasePETest
 
 
-class TestPermissionsGetPE(BasePETest):
+class TestPermissionsPE(BasePETest):
     """Testes relacionados a permissões e acesso ao Plano de Entregas de diferentes unidades."""
 
     def test_get_plano_entregas_different_unit(

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -88,7 +88,7 @@ class TestPermissionsPE(BasePETest):
         )
         assert admin_data.get("is_admin", None) is True
 
-        response = self.create_plano_entregas(
+        response = self.put_plano_entregas(
             input_pe,
             cod_unidade_autorizadora=input_pe["cod_unidade_autorizadora"],
             id_plano_entregas=input_pe["id_plano_entregas"],

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -5,7 +5,7 @@ Entregas.
 from httpx import Client
 from fastapi import status as http_status
 
-from .core_test import assert_equal_plano_entregas
+from .core_test import BasePETest
 
 
 def test_get_plano_entregas_different_unit(
@@ -61,4 +61,4 @@ def test_get_plano_entregas_different_unit_admin(
 
     assert response.status_code == http_status.HTTP_201_CREATED
     assert response.json().get("detail", None) is None
-    assert_equal_plano_entregas(response.json(), input_pe)
+    BasePETest.assert_equal_plano_entregas(response.json(), input_pe)

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -2,63 +2,64 @@
 Entregas.
 """
 
-from httpx import Client
 from fastapi import status as http_status
 
 from .core_test import BasePETest
 
 
-def test_get_plano_entregas_different_unit(
-    truncate_pe,  # pylint: disable=unused-argument
-    example_pe_unidade_3,  # pylint: disable=unused-argument
-    header_usr_2: dict,
-    input_pe,
-    client: Client,
-):
-    """Tenta buscar um plano de entregas existente em uma unidade diferente,
-    à qual o usuário não tem acesso."""
+class TestPermissionsGetPE(BasePETest):
+    """Testes relacionados a permissões e acesso ao Plano de Entregas de diferentes unidades."""
 
-    response = client.get(
-        f"/organizacao/SIAPE/3"  # Sem autorização nesta unidade
-        f"/plano_entregas/{input_pe['id_plano_entregas']}",
-        headers=header_usr_2,
-    )
-    assert response.status_code == http_status.HTTP_403_FORBIDDEN
+    def test_get_plano_entregas_different_unit(
+        self,
+        truncate_pe,  # pylint: disable=unused-argument
+        example_pe_unidade_3,  # pylint: disable=unused-argument
+        header_usr_2: dict,
+    ):
+        """Tenta buscar um plano de entregas existente em uma unidade diferente,
+        à qual o usuário não tem acesso.
+        """
+        input_pe = self.input_pe.copy()
+        response = self.get_plano_entregas(
+            input_pe["id_plano_entregas"],
+            3,  # Sem autorização nesta unidade
+            header_usr=header_usr_2,
+        )
+        assert response.status_code == http_status.HTTP_403_FORBIDDEN
 
+    def test_get_plano_entregas_different_unit_admin(
+        self,
+        truncate_pe,  # pylint: disable=unused-argument
+        header_admin: dict,
+        admin_credentials: dict,
+    ):
+        """Tenta, como administrador, criar um novo Plano de Entregas
+        em uma organização diferente da sua própria organização.
+        """
+        input_pe = self.input_pe.copy()
+        input_pe["cod_unidade_autorizadora"] = 3  # Unidade diferente
 
-def test_get_plano_entregas_different_unit_admin(
-    truncate_pe,  # pylint: disable=unused-argument
-    input_pe: dict,
-    header_admin: dict,
-    admin_credentials: dict,
-    client: Client,
-):
-    """Tenta, como administrador, criar um novo Plano de Entregas em uma
-    organização diferente da sua própria organização.
-    """
-    input_pe["cod_unidade_autorizadora"] = 3  # unidade diferente
+        response = self.client.get(
+            f"/user/{admin_credentials['username']}",
+            headers=header_admin,
+        )
 
-    response = client.get(
-        f"/user/{admin_credentials['username']}",
-        headers=header_admin,
-    )
+        # Verifica se o usuário é admin e se está em outra unidade
+        assert response.status_code == http_status.HTTP_200_OK
+        admin_data = response.json()
+        assert (
+            admin_data.get("cod_unidade_autorizadora", None)
+            != input_pe["cod_unidade_autorizadora"]
+        )
+        assert admin_data.get("is_admin", None) is True
 
-    # Verifica se o usuário é admin e se está em outra unidade
-    assert response.status_code == http_status.HTTP_200_OK
-    admin_data = response.json()
-    assert (
-        admin_data.get("cod_unidade_autorizadora", None)
-        != input_pe["cod_unidade_autorizadora"]
-    )
-    assert admin_data.get("is_admin", None) is True
+        response = self.create_plano_entregas(
+            input_pe,
+            cod_unidade_autorizadora=input_pe["cod_unidade_autorizadora"],
+            id_plano_entregas=input_pe["id_plano_entregas"],
+            header_usr=header_admin,
+        )
 
-    response = client.put(
-        f"/organizacao/SIAPE/{input_pe['cod_unidade_autorizadora']}"
-        f"/plano_entregas/{input_pe['id_plano_entregas']}",
-        json=input_pe,
-        headers=header_admin,
-    )
-
-    assert response.status_code == http_status.HTTP_201_CREATED
-    assert response.json().get("detail", None) is None
-    BasePETest.assert_equal_plano_entregas(response.json(), input_pe)
+        assert response.status_code == http_status.HTTP_201_CREATED
+        assert response.json().get("detail", None) is None
+        self.assert_equal_plano_entregas(response.json(), input_pe)

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -27,6 +27,41 @@ class TestPermissionsPE(BasePETest):
         )
         assert response.status_code == http_status.HTTP_403_FORBIDDEN
 
+    def test_get_plano_entregas_different_unit_admin(
+        self,
+        truncate_pe,  # pylint: disable=unused-argument
+        example_pe_unidade_3,  # pylint: disable=unused-argument
+        header_admin: dict,
+        admin_credentials: dict,
+    ):
+        """Tenta, como administrador, buscar um Plano de Entregas
+        em uma organização diferente da sua própria organização.
+        """
+        input_pe = self.input_pe.copy()
+        input_pe["cod_unidade_autorizadora"] = 3
+
+        response = self.client.get(
+            f"/user/{admin_credentials['username']}",
+            headers=header_admin,
+        )
+
+        # Verifica se o usuário é admin e se está em outra unidade
+        assert response.status_code == http_status.HTTP_200_OK
+        admin_data = response.json()
+        assert (
+            admin_data.get("cod_unidade_autorizadora", None)
+            != input_pe["cod_unidade_autorizadora"]
+        )
+        assert admin_data.get("is_admin", None) is True
+
+        response = self.get_plano_entregas(
+            input_pe["id_plano_entregas"],
+            input_pe["cod_unidade_autorizadora"],
+            header_usr=header_admin,
+        )
+
+        assert response.status_code == http_status.HTTP_200_OK
+
     def test_put_plano_entregas_different_unit_admin(
         self,
         truncate_pe,  # pylint: disable=unused-argument

--- a/tests/plano_entregas/permissions_test.py
+++ b/tests/plano_entregas/permissions_test.py
@@ -27,7 +27,7 @@ class TestPermissionsGetPE(BasePETest):
         )
         assert response.status_code == http_status.HTTP_403_FORBIDDEN
 
-    def test_get_plano_entregas_different_unit_admin(
+    def test_put_plano_entregas_different_unit_admin(
         self,
         truncate_pe,  # pylint: disable=unused-argument
         header_admin: dict,

--- a/tests/plano_trabalho/avaliacao_registros_execucao_test.py
+++ b/tests/plano_trabalho/avaliacao_registros_execucao_test.py
@@ -36,7 +36,7 @@ class TestCreatePTMissingMandatoryFieldsAvaliacaoRegistrosExecucao(BasePTTest):
             input_pt["avaliacoes_registros_execucao"][0][field] = None
 
         input_pt["id_plano_trabalho"] = "111222333"
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -70,7 +70,7 @@ class TestCreatePTInvalidAvaliacaoRegistrosExecucao(BasePTTest):
             "avaliacao_registros_execucao"
         ] = avaliacao_registros_execucao
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if avaliacao_registros_execucao in range(1, 6):
             assert response.status_code == status.HTTP_201_CREATED
@@ -208,7 +208,7 @@ class TestCreatePTInvalidAvaliacaoRegistrosExecucaoDates(BasePTTest):
             "data_avaliacao_registros_execucao"
         ] = data_avaliacao_registros_execucao
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if date.fromisoformat(data_avaliacao_registros_execucao) > date.fromisoformat(
             data_inicio_periodo_avaliativo

--- a/tests/plano_trabalho/avaliacao_registros_execucao_test.py
+++ b/tests/plano_trabalho/avaliacao_registros_execucao_test.py
@@ -36,7 +36,7 @@ class TestCreatePTMissingMandatoryFieldsAvaliacaoRegistrosExecucao(BasePTTest):
             input_pt["avaliacoes_registros_execucao"][0][field] = None
 
         input_pt["id_plano_trabalho"] = "111222333"
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -70,7 +70,7 @@ class TestCreatePTInvalidAvaliacaoRegistrosExecucao(BasePTTest):
             "avaliacao_registros_execucao"
         ] = avaliacao_registros_execucao
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if avaliacao_registros_execucao in range(1, 6):
             assert response.status_code == status.HTTP_201_CREATED
@@ -208,7 +208,7 @@ class TestCreatePTInvalidAvaliacaoRegistrosExecucaoDates(BasePTTest):
             "data_avaliacao_registros_execucao"
         ] = data_avaliacao_registros_execucao
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if date.fromisoformat(data_avaliacao_registros_execucao) > date.fromisoformat(
             data_inicio_periodo_avaliativo

--- a/tests/plano_trabalho/contribuicoes_test.py
+++ b/tests/plano_trabalho/contribuicoes_test.py
@@ -45,7 +45,7 @@ class TestCreatePTMissingMandatoryFieldsContribuicoes(BasePTTest):
             "percentual_contribuicao"
         ] = percentual_contribuicao
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -70,7 +70,7 @@ class TestCreatePTInvalidTipoContribuicao(BasePTTest):
         input_pt = self.input_pt.copy()
         input_pt["contribuicoes"][0]["tipo_contribuicao"] = tipo_contribuicao
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if tipo_contribuicao in [1, 2, 3]:
             assert response.status_code == status.HTTP_201_CREATED
@@ -105,7 +105,7 @@ class TestPercentualContribuicao(BasePTTest):
             "percentual_contribuicao"
         ] = percentual_contribuicao
 
-        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
+        response = self.put_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         if 0 <= percentual_contribuicao <= 100:
             assert response.status_code == status.HTTP_201_CREATED
@@ -142,7 +142,7 @@ class TestCreatePTOmitOptionalFields(BasePTTest):
                     del contribuicao[field]
 
         partial_input_pt["id_plano_trabalho"] = str(557 + offset)
-        response = self.create_plano_trabalho(partial_input_pt)
+        response = self.put_plano_trabalho(partial_input_pt)
         assert response.status_code == status.HTTP_201_CREATED
 
 
@@ -173,7 +173,7 @@ class TestCreatePTNullOptionalFields(BasePTTest):
                     contribuicao[field] = None
 
         partial_input_pt["id_plano_trabalho"] = str(557 + offset)
-        response = self.create_plano_trabalho(partial_input_pt)
+        response = self.put_plano_trabalho(partial_input_pt)
         assert response.status_code == status.HTTP_201_CREATED
 
 
@@ -223,7 +223,7 @@ class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
         contribuicao["tipo_contribuicao"] = tipo_contribuicao
         contribuicao["id_plano_entregas"] = id_plano_entregas
         contribuicao["id_entrega"] = id_entrega
-        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
+        response = self.put_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         error_messages = []
         if tipo_contribuicao == 1:
@@ -263,7 +263,7 @@ class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
         contribuicao["id_plano_entregas"] = id_plano_entregas
         contribuicao["id_entrega"] = id_entrega
 
-        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
+        response = self.put_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         if id_plano_entregas == input_pe["id_plano_entregas"] and \
             id_entrega in [entrega["id_entrega"] for entrega in input_pe["entregas"]]:

--- a/tests/plano_trabalho/contribuicoes_test.py
+++ b/tests/plano_trabalho/contribuicoes_test.py
@@ -45,7 +45,7 @@ class TestCreatePTMissingMandatoryFieldsContribuicoes(BasePTTest):
             "percentual_contribuicao"
         ] = percentual_contribuicao
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
 
@@ -70,7 +70,7 @@ class TestCreatePTInvalidTipoContribuicao(BasePTTest):
         input_pt = self.input_pt.copy()
         input_pt["contribuicoes"][0]["tipo_contribuicao"] = tipo_contribuicao
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if tipo_contribuicao in [1, 2, 3]:
             assert response.status_code == status.HTTP_201_CREATED
@@ -105,7 +105,7 @@ class TestPercentualContribuicao(BasePTTest):
             "percentual_contribuicao"
         ] = percentual_contribuicao
 
-        response = self.create_pt(input_pt, header_usr=self.header_usr_1)
+        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         if 0 <= percentual_contribuicao <= 100:
             assert response.status_code == status.HTTP_201_CREATED
@@ -142,7 +142,7 @@ class TestCreatePTOmitOptionalFields(BasePTTest):
                     del contribuicao[field]
 
         partial_input_pt["id_plano_trabalho"] = str(557 + offset)
-        response = self.create_pt(partial_input_pt)
+        response = self.create_plano_trabalho(partial_input_pt)
         assert response.status_code == status.HTTP_201_CREATED
 
 
@@ -173,7 +173,7 @@ class TestCreatePTNullOptionalFields(BasePTTest):
                     contribuicao[field] = None
 
         partial_input_pt["id_plano_trabalho"] = str(557 + offset)
-        response = self.create_pt(partial_input_pt)
+        response = self.create_plano_trabalho(partial_input_pt)
         assert response.status_code == status.HTTP_201_CREATED
 
 
@@ -223,7 +223,7 @@ class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
         contribuicao["tipo_contribuicao"] = tipo_contribuicao
         contribuicao["id_plano_entregas"] = id_plano_entregas
         contribuicao["id_entrega"] = id_entrega
-        response = self.create_pt(input_pt, header_usr=self.header_usr_1)
+        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         error_messages = []
         if tipo_contribuicao == 1:
@@ -263,7 +263,7 @@ class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
         contribuicao["id_plano_entregas"] = id_plano_entregas
         contribuicao["id_entrega"] = id_entrega
 
-        response = self.create_pt(input_pt, header_usr=self.header_usr_1)
+        response = self.create_plano_trabalho(input_pt, header_usr=self.header_usr_1)
 
         if id_plano_entregas == input_pe["id_plano_entregas"] and \
             id_entrega in [entrega["id_entrega"] for entrega in input_pe["entregas"]]:

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -82,8 +82,10 @@ class BasePTTest:
         """Configurar o ambiente de teste.
 
         Args:
-            truncate_pe (callable): Fixture para truncar a tabela PE.
-            truncate_pt (callable): Fixture para truncar a tabela PT.
+            truncate_pe (callable): Fixture para truncar a tabela de
+                Planos de Entrega.
+            truncate_pt (callable): Fixture para truncar a tabela de
+                Planos de Trabalho.
             example_pe (callable): Fixture que cria exemplo de PE.
             input_pt (dict): Dados usados para ciar um PT
             user1_credentials (dict): Credenciais do usuário 1.

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -150,7 +150,7 @@ class BasePTTest:
         )
         assert avaliacao_registros_execucao_1 == avaliacao_registros_execucao_2
 
-    def create_pt(
+    def create_plano_trabalho(
         self,
         input_pt: dict,
         id_plano_trabalho: Optional[str] = None,
@@ -190,7 +190,7 @@ class BasePTTest:
         )
         return response
 
-    def get_pt(
+    def get_plano_trabalho(
         self,
         id_plano_trabalho: str,
         cod_unidade_autorizadora: int,
@@ -227,13 +227,13 @@ class TestCreatePlanoTrabalho(BasePTTest):
         """Cria um novo Plano de Trabalho do Participante, em uma unidade
         na qual ele está autorizado, contendo todos os dados necessários.
         """
-        response = self.create_pt(self.input_pt)
+        response = self.create_plano_trabalho(self.input_pt)
 
         assert response.status_code == status.HTTP_201_CREATED
         self.assert_equal_plano_trabalho(response.json(), self.input_pt)
 
         # Consulta API para conferir se a criação foi persistida
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             self.input_pt["id_plano_trabalho"],
             self.input_pt["cod_unidade_autorizadora"],
         )
@@ -270,7 +270,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["id_plano_trabalho"] = f"{1800 + offset}"  # precisa ser um novo plano
 
         # Act
-        response = self.create_pt(input_pt, **placeholder_fields)
+        response = self.create_plano_trabalho(input_pt, **placeholder_fields)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -284,7 +284,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["id_plano_trabalho"] = "110"
 
         # Act
-        response = self.create_pt(
+        response = self.create_plano_trabalho(
             input_pt, id_plano_trabalho="111", header_usr=self.header_usr_1
         )
 
@@ -310,7 +310,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["carga_horaria_disponivel"] = carga_horaria_disponivel
 
         # Act
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -356,7 +356,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["cpf_participante"] = cpf_participante
 
         # Act
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -408,12 +408,12 @@ class TestUpdatePlanoDeTrabalho(BasePTTest):
         input_pt = self.input_pt.copy()
         input_pt["status"] = 4  # Valor era 3
         input_pt["data_termino"] = "2023-01-31"  # Valor era "2023-01-15"
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_200_OK
         self.assert_equal_plano_trabalho(response.json(), input_pt)
 
         # Consulta API para conferir se a alteração foi persistida
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             input_pt["id_plano_trabalho"],
             self.user1_credentials["cod_unidade_autorizadora"],
         )
@@ -433,7 +433,7 @@ class TestGetPlanoTrabalho(BasePTTest):
         input_pt["contribuicoes"][1]["id_entrega"] = None
         input_pt["contribuicoes"][1]["descricao_contribuicao"] = None
 
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             input_pt["id_plano_trabalho"], input_pt["cod_unidade_autorizadora"]
         )
 
@@ -444,7 +444,7 @@ class TestGetPlanoTrabalho(BasePTTest):
         """Tenta acessar um plano de trabalho inexistente."""
         non_existent_id = "888888888"
 
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             non_existent_id, self.user1_credentials["cod_unidade_autorizadora"]
         )
 

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -150,7 +150,7 @@ class BasePTTest:
         )
         assert avaliacao_registros_execucao_1 == avaliacao_registros_execucao_2
 
-    def create_plano_trabalho(
+    def put_plano_trabalho(
         self,
         input_pt: dict,
         id_plano_trabalho: Optional[str] = None,
@@ -158,7 +158,7 @@ class BasePTTest:
         cod_unidade_autorizadora: Optional[int] = None,
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Criar um Plano de Trabalho.
+        """Cria ou atualiza um Plano de Trabalho pela API, usando o verbo PUT.
 
         Args:
             input_pt (dict): O dicionário de entrada do Plano de Trabalho.
@@ -197,7 +197,7 @@ class BasePTTest:
         origem_unidade: Optional[str] = "SIAPE",
         header_usr: Optional[dict] = None,
     ) -> Response:
-        """Obter um Plano de Trabalho.
+        """Obtém um Plano de Trabalho pela API, usando o verbo GET.
 
         Args:
             id_plano_trabalho (str): O ID do Plano de Trabalho.
@@ -227,7 +227,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         """Cria um novo Plano de Trabalho do Participante, em uma unidade
         na qual ele está autorizado, contendo todos os dados necessários.
         """
-        response = self.create_plano_trabalho(self.input_pt)
+        response = self.put_plano_trabalho(self.input_pt)
 
         assert response.status_code == status.HTTP_201_CREATED
         self.assert_equal_plano_trabalho(response.json(), self.input_pt)
@@ -270,7 +270,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["id_plano_trabalho"] = f"{1800 + offset}"  # precisa ser um novo plano
 
         # Act
-        response = self.create_plano_trabalho(input_pt, **placeholder_fields)
+        response = self.put_plano_trabalho(input_pt, **placeholder_fields)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -284,7 +284,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["id_plano_trabalho"] = "110"
 
         # Act
-        response = self.create_plano_trabalho(
+        response = self.put_plano_trabalho(
             input_pt, id_plano_trabalho="111", header_usr=self.header_usr_1
         )
 
@@ -310,7 +310,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["carga_horaria_disponivel"] = carga_horaria_disponivel
 
         # Act
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -356,7 +356,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
         input_pt["cpf_participante"] = cpf_participante
 
         # Act
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
@@ -408,7 +408,7 @@ class TestUpdatePlanoDeTrabalho(BasePTTest):
         input_pt = self.input_pt.copy()
         input_pt["status"] = 4  # Valor era 3
         input_pt["data_termino"] = "2023-01-31"  # Valor era "2023-01-15"
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_200_OK
         self.assert_equal_plano_trabalho(response.json(), input_pt)
 

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -5,7 +5,7 @@ participante.
 
 from typing import Optional
 
-from httpx import Client
+from httpx import Client, Response
 from fastapi import status
 
 import pytest
@@ -157,7 +157,7 @@ class BasePTTest:
         origem_unidade: Optional[str] = None,
         cod_unidade_autorizadora: Optional[int] = None,
         header_usr: Optional[dict] = None,
-    ):
+    ) -> Response:
         """Criar um Plano de Trabalho.
 
         Args:
@@ -196,7 +196,7 @@ class BasePTTest:
         cod_unidade_autorizadora: int,
         origem_unidade: Optional[str] = "SIAPE",
         header_usr: Optional[dict] = None,
-    ):
+    ) -> Response:
         """Obter um Plano de Trabalho.
 
         Args:

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -68,7 +68,7 @@ class TestCreatePTInvalidDates(BasePTTest):
         assert response.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
 
         # cria o plano_trabalho com a data_inicio informada
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
         if data_inicio > data_termino:
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
             detail_message = (
@@ -100,7 +100,7 @@ class TestCreatePTDateIntervalOverAYear(BasePTTest):
         input_pt["data_inicio"] = data_inicio
         input_pt["data_termino"] = data_termino
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if (
             over_a_year(
@@ -210,7 +210,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 "carga_horaria_disponivel": 80,
             }
         ]
-        response = self.create_plano_trabalho(input_pt2)
+        response = self.put_plano_trabalho(input_pt2)
         assert response.status_code == status.HTTP_201_CREATED
 
         input_pt["id_plano_trabalho"] = id_plano_trabalho
@@ -220,7 +220,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
         input_pt["data_termino"] = data_termino
         input_pt["status"] = status_pt
         input_pt["avaliacoes_registros_execucao"] = []
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if (
             # se algum dos planos estiver cancelado, não há problema em haver
@@ -303,7 +303,7 @@ class TestCreatePTDataAvaliacao(BasePTTest):
             "data_fim_periodo_avaliativo"
         ] = data_fim_periodo_avaliativo
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         if date.fromisoformat(data_fim_periodo_avaliativo) < date.fromisoformat(
             data_inicio_periodo_avaliativo
@@ -357,7 +357,7 @@ class TestCreatePTDataAvaliacao(BasePTTest):
             "data_avaliacao_registros_execucao"
         ] = data_avaliacao_registros_execucao
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
         if date.fromisoformat(data_avaliacao_registros_execucao) < date.fromisoformat(
             data_inicio_periodo_avaliativo
         ):
@@ -442,7 +442,7 @@ class TestCreatePlanoDeTrabalhoPeriodoAvaliativoOverlapping(BasePTTest):
             avaliacao_template["data_avaliacao_registros_execucao"] = "2024-01-01"
             input_pt["avaliacoes_registros_execucao"].append(avaliacao_template)
 
-        response = self.create_plano_trabalho(input_pt)
+        response = self.put_plano_trabalho(input_pt)
 
         periodo_avaliativo.sort(key=lambda avaliacao: avaliacao[0])
         for avaliacao_1, avaliacao_2 in zip(

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -68,7 +68,7 @@ class TestCreatePTInvalidDates(BasePTTest):
         assert response.status_code in (status.HTTP_200_OK, status.HTTP_201_CREATED)
 
         # cria o plano_trabalho com a data_inicio informada
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
         if data_inicio > data_termino:
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
             detail_message = (
@@ -100,7 +100,7 @@ class TestCreatePTDateIntervalOverAYear(BasePTTest):
         input_pt["data_inicio"] = data_inicio
         input_pt["data_termino"] = data_termino
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if (
             over_a_year(
@@ -210,7 +210,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 "carga_horaria_disponivel": 80,
             }
         ]
-        response = self.create_pt(input_pt2)
+        response = self.create_plano_trabalho(input_pt2)
         assert response.status_code == status.HTTP_201_CREATED
 
         input_pt["id_plano_trabalho"] = id_plano_trabalho
@@ -220,7 +220,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
         input_pt["data_termino"] = data_termino
         input_pt["status"] = status_pt
         input_pt["avaliacoes_registros_execucao"] = []
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if (
             # se algum dos planos estiver cancelado, não há problema em haver
@@ -303,7 +303,7 @@ class TestCreatePTDataAvaliacao(BasePTTest):
             "data_fim_periodo_avaliativo"
         ] = data_fim_periodo_avaliativo
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         if date.fromisoformat(data_fim_periodo_avaliativo) < date.fromisoformat(
             data_inicio_periodo_avaliativo
@@ -357,7 +357,7 @@ class TestCreatePTDataAvaliacao(BasePTTest):
             "data_avaliacao_registros_execucao"
         ] = data_avaliacao_registros_execucao
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
         if date.fromisoformat(data_avaliacao_registros_execucao) < date.fromisoformat(
             data_inicio_periodo_avaliativo
         ):
@@ -442,7 +442,7 @@ class TestCreatePlanoDeTrabalhoPeriodoAvaliativoOverlapping(BasePTTest):
             avaliacao_template["data_avaliacao_registros_execucao"] = "2024-01-01"
             input_pt["avaliacoes_registros_execucao"].append(avaliacao_template)
 
-        response = self.create_pt(input_pt)
+        response = self.create_plano_trabalho(input_pt)
 
         periodo_avaliativo.sort(key=lambda avaliacao: avaliacao[0])
         for avaliacao_1, avaliacao_2 in zip(

--- a/tests/plano_trabalho/permissions_test.py
+++ b/tests/plano_trabalho/permissions_test.py
@@ -83,7 +83,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
             header_usr_2 (dict): Cabeçalho do usuário na unidade diferente.
         """
         # Criar o Plano de Trabalho em uma unidade diferente
-        response = self.create_plano_trabalho(
+        response = self.put_plano_trabalho(
             self.input_pt, cod_unidade_autorizadora=3, header_usr=header_usr_2
         )
 
@@ -128,7 +128,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
         assert admin_data.get("is_admin", None) is True
 
         # Criar o Plano de Trabalho em uma unidade diferente
-        response = self.create_plano_trabalho(
+        response = self.put_plano_trabalho(
             input_pt, cod_unidade_autorizadora=3, header_usr=header_admin
         )
 

--- a/tests/plano_trabalho/permissions_test.py
+++ b/tests/plano_trabalho/permissions_test.py
@@ -29,7 +29,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
             example_pe_unidade_3: Fixture para criar um PE na unidade 3.
             example_pt_unidade_3: Fixture para criar um PT na unidade 3.
         """
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             id_plano_trabalho=self.input_pt["id_plano_trabalho"],
             cod_unidade_autorizadora=3,  # Unidade diferente
             header_usr=header_usr_2,
@@ -60,7 +60,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
         input_pt = self.input_pt.copy()
 
         # Obter o plano de trabalho de uma unidade diferente
-        response = self.get_pt(
+        response = self.get_plano_trabalho(
             self.input_pt["id_plano_trabalho"], 3, header_usr=header_admin
         )
 
@@ -83,7 +83,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
             header_usr_2 (dict): Cabeçalho do usuário na unidade diferente.
         """
         # Criar o Plano de Trabalho em uma unidade diferente
-        response = self.create_pt(
+        response = self.create_plano_trabalho(
             self.input_pt, cod_unidade_autorizadora=3, header_usr=header_usr_2
         )
 
@@ -128,7 +128,7 @@ class TestPlanoDeTrabalhoDiferenteUnidade(BasePTTest):
         assert admin_data.get("is_admin", None) is True
 
         # Criar o Plano de Trabalho em uma unidade diferente
-        response = self.create_pt(
+        response = self.create_plano_trabalho(
             input_pt, cod_unidade_autorizadora=3, header_usr=header_admin
         )
 


### PR DESCRIPTION
Remove code redundancy and simplify maintenance by refactoring isolated test functions into test classes that contain similar tests.