### PR TITLE
Add additional explanation about cod_unidade_autorizacao

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,12 @@
 # Release notes
 
 
+## 3.2.1
+
+* Add additional explanation about cod_unidade_autorizadora in the
+  documentation.
+
+
 ## 3.2.0
 
 * Make `data_assinatura_tcr` not nullable

--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -102,7 +102,10 @@ termos de SIAPE, geralmente é o código Uorg Lv1. O próprio Decreto,
 contudo, indica que tal autoridade poderá ser delegada a dois níveis
 hierárquicos imediatamente inferiores, ou seja, para Uorg Lv2 e Uorg Lv3.
 Haverá situações, portanto, em que uma unidade do Uorg Lv1 de nível 2 ou
-3 poderá enviar dados diretamente para API.
+3 poderá enviar dados diretamente para API. Deve corresponder à
+instituição com poder de autorização. Ou seja, ainda que tenha optado por
+usar antigas portarias ministeriais de autorização, é hoje a UORG
+responsável pelo envio dos dados.
 
 Exemplo: "Ministério da Gestão e da Inovação em Serviços Públicos" ou
 "Conselho de Controle de Atividades Financeiras"

--- a/src/models.py
+++ b/src/models.py
@@ -628,7 +628,10 @@ class Participante(Base):
         "indica que tal autoridade poderá ser delegada a dois níveis "
         "hierárquicos imediatamente inferiores, ou seja, para Uorg Lv2 e Uorg "
         "Lv3. Haverá situações, portanto, em que uma unidade do Uorg Lv1 de "
-        "nível 2 ou 3 poderá enviar dados diretamente para API.\n\n"
+        "nível 2 ou 3 poderá enviar dados diretamente para API. Deve "
+        "corresponder à instituição com poder de autorização. Ou seja, ainda "
+        "que tenha optado por usar antigas portarias ministeriais de "
+        "autorização, é hoje a UORG responsável pelo envio dos dados.\n\n"
         'Exemplo: "Ministério da Gestão e da Inovação em Serviços Públicos" '
         'ou "Conselho de Controle de Atividades Financeiras"\n\n'
         "Obs: A instituição que não esteja no SIAPE pode usar o código SIORG.",


### PR DESCRIPTION
Add the requested text in the API and `cod_unidade_autorizacao` field descriptions.

Fix #135.