### PR TITLE
Handle error when attempting to log in with a non-existing user

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,11 @@
 # Release notes
 
 
+## 3.2.2
+
+* Handle error when attempting to log in with a non-existing user
+
+
 ## 3.2.1
 
 * Add additional explanation about cod_unidade_autorizadora in the

--- a/src/crud_auth.py
+++ b/src/crud_auth.py
@@ -108,10 +108,7 @@ async def authenticate_user(
     """
     user = await get_user(db_session=db, email=username)
 
-    if not user:
-        return False
-
-    if not verify_password(password, user.password):
+    if not user or not verify_password(password, user.password):
         raise InvalidCredentialsError("Username ou password incorretos")
 
     if user.disabled:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -208,6 +208,12 @@ def fixture_register_user_2(
 
 
 @pytest.fixture()
+def non_existing_user_credentials() -> dict:
+    """Retorna pseudo credenciais de um usuário não existente."""
+    return {"email": "naoexiste@naoexiste.com", "password": "inexistente"}
+
+
+@pytest.fixture()
 def disabled_user_1(
     header_admin: dict,  # pylint: disable=unused-argument
     user1_credentials: dict,

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -179,6 +179,24 @@ class TestUserAuthentication(BaseUserTest):
         token = header_usr_1.get("Authorization")
         assert isinstance(token, str)
 
+    def test_attempt_log_in_non_existent_user(
+        self,
+        truncate_users,  # pylint: disable=unused-argument
+        non_existing_user_credentials: dict,
+    ):
+        """Tenta fazer login com um usuário que não existe.
+
+        Args:
+            truncate_users (fixture): Trunca a tabela de usuários.
+            non_existing_user_credentials (dict): Credenciais do usuário 1.
+        """
+        # Faz login com um usuário que não existe.
+        with pytest.raises(HTTPStatusError):
+            self.get_bearer_token(
+                username=non_existing_user_credentials["email"],
+                password=non_existing_user_credentials["password"],
+            )
+
     def test_attempt_log_in_disabled_user(
         self,
         truncate_users,  # pylint: disable=unused-argument


### PR DESCRIPTION
Fix #145