### PR TITLE
feat: Implementação de endpoints para apagar registros e consertar a migração

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ mnt/
 .pyenv
 .pytest_cache
 .DS_Store
+.idea

--- a/src/api.py
+++ b/src/api.py
@@ -892,19 +892,19 @@ async def delete_participante(
     status_code=status.HTTP_204_NO_CONTENT
 )
 
-async def delete_all(
+async def delete_all_migration(
     user: Annotated[schemas.UsersSchema, Depends(crud_auth.get_current_active_user)],
     origem_unidade: str,
     cod_unidade_autorizadora: int,
     db: DbContextManager = Depends(DbContextManager),
 ) -> Response:
-    """Exclui um plano de entregas."""
+    """Exclui Todas as migrações de uma unidade autorizadora"""
 
     # Validações de permissão
     check_permissions(origem_unidade, cod_unidade_autorizadora, user)
 
     try:
-        await crud.delete_all_per_organizacao(
+        await crud.delete_all_per_unidade_autorizadora(
             db_session=db,
             origem_unidade=origem_unidade,
             cod_unidade_autorizadora=cod_unidade_autorizadora

--- a/src/api.py
+++ b/src/api.py
@@ -500,7 +500,7 @@ async def delete_plano_entregas(
     try:
         if not db_plano_entregas:
             raise HTTPException(
-                status.HTTP_404_NOT_FOUND, detail="Plano de entrega não encontrado"
+                status.HTTP_404_NOT_FOUND, detail="Plano de entregas não encontrado"
             )
         else:
             await crud.delete_plano_entregas(

--- a/src/api.py
+++ b/src/api.py
@@ -1,25 +1,28 @@
 """Definição das rotas, endpoints e seu comportamento na API.
 """
 
+import json
+import logging
+import os
 from contextlib import asynccontextmanager
 from datetime import timedelta
-import json
-import os
 from typing import Annotated, Union
 
 from fastapi import Depends, FastAPI, HTTPException, status, Header, Request, Response
-from fastapi.security import OAuth2PasswordRequestForm
 from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.exc import IntegrityError
-
 
 import crud
 import crud_auth
-from db_config import DbContextManager, create_db_and_tables
 import email_config
 import response_schemas
 import schemas
+from db_config import DbContextManager, create_db_and_tables
 from util import check_permissions
+
+LOGGER = logging.getLogger(__name__)
+
 
 ACCESS_TOKEN_EXPIRE_MINUTES = int(os.environ.get("ACCESS_TOKEN_EXPIRE_MINUTES"))
 TEST_ENVIRONMENT = os.environ.get("TEST_ENVIRONMENT", "False") == "True"
@@ -911,6 +914,7 @@ async def delete_all_migration(
         )
         return Response(status_code=status.HTTP_204_NO_CONTENT)
     except IntegrityError as exception:
+        LOGGER.error(exception)
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=f"IntegrityError: {str(exception)}",

--- a/src/crud.py
+++ b/src/crud.py
@@ -634,7 +634,7 @@ async def delete_participante(
     return None
 
 
-async def delete_all_per_organizacao(
+async def delete_all_per_unidade_autorizadora(
     db_session: DbContextManager,
     origem_unidade: str,
     cod_unidade_autorizadora: int

--- a/tests/migracao/core_test.py
+++ b/tests/migracao/core_test.py
@@ -1,0 +1,99 @@
+"""
+Testes relacionados às funcionalidades básicas da limpeza de migração
+"""
+
+from typing import Optional
+
+import pytest
+from fastapi import status
+from httpx import Client, Response
+
+# grupos de campos opcionais e obrigatórios a testar
+
+FIELDS_MIGRACAO = {
+    "optional": tuple(),  # nenhum campo é opcional
+    "mandatory": (
+        ["origem_unidade"],
+        ["cod_unidade_autorizadora"]
+    ),
+}
+
+
+# Classe base de testes
+
+class BaseMigracaoTest:
+    """Classe base para testes da limpeza de migração."""
+
+    # pylint: disable=too-many-arguments
+    @pytest.fixture(autouse=True)
+    def setup(
+            self,
+            truncate_participantes,  # pylint: disable=unused-argument
+            truncate_pe,  # pylint: disable=unused-argument
+            truncate_pt,  # pylint: disable=unused-argument
+            example_pe,  # pylint: disable=unused-argument
+            example_part,  # pylint: disable=unused-argument
+            example_pt,  # pylint: disable=unused-argument
+            input_pt: dict,
+            user1_credentials: dict,
+            header_usr_1: dict,
+            header_usr_2: dict,
+            client: Client,
+    ):
+        """Configurar o ambiente de teste.
+
+        Args:
+            truncate_participantes (callable): Fixture para truncar a tabela de
+                Participantes.
+            truncate_pe (callable): Fixture para truncar a tabela de
+                Planos de Entrega.
+            truncate_pt (callable): Fixture para truncar a tabela de
+                Planos de Trabalho.
+            example_pe (callable): Fixture que cria exemplo de PE.
+            input_pt (dict): Dados usados para ciar um PT
+            user1_credentials (dict): Credenciais do usuário 1.
+            header_usr_1 (dict): Cabeçalhos HTTP para o usuário 1.
+            header_usr_2 (dict): Cabeçalhos HTTP para o usuário 2.
+            client (Client): Uma instância do cliente HTTPX.
+        """
+        # pylint: disable=attribute-defined-outside-init
+        self.input_pt = input_pt
+        self.user1_credentials = user1_credentials
+        self.header_usr_1 = header_usr_1
+        self.header_usr_2 = header_usr_2
+        self.client = client
+
+    def delete_migracao(
+            self,
+            cod_unidade_autorizadora: int,
+            origem_unidade: Optional[str] = "SIAPE",
+            header_usr: Optional[dict] = None,
+    ) -> Response:
+        """Executa a limpeza de migração
+
+        Args:
+            cod_unidade_autorizadora (int): O ID da unidade autorizadora.
+            origem_unidade (str): origem do código da unidade.
+            header_usr (dict): Cabeçalhos HTTP para o usuário.
+
+        Returns:
+            httpx.Response: A resposta da API.
+        """
+        if header_usr is None:
+            header_usr = self.header_usr_1
+        response = self.client.delete(
+            (
+                f"/organizacao/{origem_unidade}/{cod_unidade_autorizadora}"
+                f"/limpar-migracao"
+            ),
+            headers=header_usr,
+        )
+        return response
+
+
+class TestDeletarMigracao(BaseMigracaoTest):
+    """Testes para exclusão da migração."""
+
+    def test_delete_migracao_success(self, example_pt, example_pe, example_part):  # pylint: disable=unused-argument
+        response = self.delete_migracao(self.input_pt["cod_unidade_autorizadora"])
+        assert response.status_code == status.HTTP_204_NO_CONTENT

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -639,7 +639,13 @@ class TestCreateParticipanteDateValidation(BaseParticipanteTest):
 class TestDeleteParticipante(BaseParticipanteTest):
     """Testes para a exclusão de Participantes."""
 
-    def test_delete_participante(self, example_part):  # pylint: disable=unused-argument
+    def test_delete_participante_success(self, example_part):  # pylint: disable=unused-argument
+        response = self.get_participante(
+            matricula_siape=self.input_part["matricula_siape"],
+            cod_unidade_autorizadora=self.input_part["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=self.input_part["cod_unidade_lotacao"])
+        assert response.status_code == status.HTTP_200_OK
+
         response = self.delete_participante(
             matricula_siape=self.input_part["matricula_siape"],
             cod_unidade_autorizadora=self.input_part["cod_unidade_autorizadora"],
@@ -647,7 +653,13 @@ class TestDeleteParticipante(BaseParticipanteTest):
         )
         assert response.status_code == status.HTTP_204_NO_CONTENT
 
-    def test_delete_participante_not_found(self):
+        response = self.get_participante(
+            matricula_siape=self.input_part["matricula_siape"],
+            cod_unidade_autorizadora=self.input_part["cod_unidade_autorizadora"],
+            cod_unidade_lotacao=self.input_part["cod_unidade_lotacao"])
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    def test_delete_participante_fail_when_not_found(self):
         response = self.delete_participante(
             matricula_siape=3311776,
             cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
@@ -656,7 +668,7 @@ class TestDeleteParticipante(BaseParticipanteTest):
         assert response.status_code == status.HTTP_404_NOT_FOUND
         assert response.json().get("detail", None) == "Participante não encontrado"
 
-    def test_delete_participante_with_plano_trabalho(self, example_part: dict, example_pt: dict):
+    def test_delete_participante_fail_with_plano_trabalho(self, example_part: dict, example_pt: dict):
         response = self.delete_participante(
             matricula_siape=self.input_part["matricula_siape"],
             cod_unidade_autorizadora=self.input_part["cod_unidade_autorizadora"],
@@ -664,7 +676,7 @@ class TestDeleteParticipante(BaseParticipanteTest):
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
         assert response.json().get("detail", None) == "Existe um ou mais planos de trabalho associados a este participante"
 
-    def test_delete_participante_in_different_unit(
+    def test_delete_participante_fail_when_different_unit(
             self, example_part_unidade_3: dict  # pylint: disable=unused-argument
     ):
         input_part = deepcopy(self.input_part)

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -6,10 +6,9 @@ from copy import deepcopy
 from datetime import date, datetime, timedelta, timezone
 from typing import Optional
 
+import pytest
 from fastapi import status
 from httpx import Client, Response
-
-import pytest
 
 # Relação de campos obrigatórios para testar sua ausência:
 FIELDS_PARTICIPANTES = {

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -5,11 +5,9 @@ Testes relacionados ao Plano de Entregas da Unidade
 from copy import deepcopy
 from typing import Optional
 
-from httpx import Client, Response
-from fastapi import status as http_status
-
 import pytest
-
+from fastapi import status as http_status
+from httpx import Client, Response
 from util import assert_error_message
 
 # constantes

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -6,11 +6,9 @@ participante.
 from copy import deepcopy
 from typing import Optional
 
-from httpx import Client, Response
-from fastapi import status
-
 import pytest
-
+from fastapi import status
+from httpx import Client, Response
 from util import assert_error_message
 
 # grupos de campos opcionais e obrigatórios a testar


### PR DESCRIPTION
Olá, sou Henrique Dutra servidor da UFRN.

Detectei um problema na nossa migração (UFRN) e precisamos resetar a migração que foi realizada em produção para ser feita novamente, mas atualmente a API PGD não nos oferece esse mecanismo.

No total foram implementados quatro endpoints para excluir registros. 

Um endpoint para resetar a migração, excluindo todos os registros de uma organização.

Outros três são para excluir apenas linhas de acordo com os parâmetros em: participante, plano de entregas e plano de trabalho.

Aguardo um feedback sobre nossa proposta.