### PR TITLE
Tratar adequadamente quando o valor null é passado no campo contribuicoes do plano_trabalho

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,6 +1,13 @@
 # Release notes
 
 
+## 3.2.3
+
+* Handle error when submitting a PUT for plano_trabalho with a json
+  value of null for the contribuicoes field. It is now allowed and
+  handled properly (optional field)
+
+
 ## 3.2.2
 
 * Handle error when attempting to log in with a non-existing user

--- a/src/crud.py
+++ b/src/crud.py
@@ -148,7 +148,9 @@ async def create_plano_trabalho(
             .filter_by(origem_unidade=plano_trabalho.origem_unidade)
             .filter_by(cod_unidade_autorizadora=plano_trabalho.cod_unidade_autorizadora)
             .filter_by(matricula_siape=plano_trabalho.matricula_siape)
-            .filter_by(cod_unidade_lotacao=plano_trabalho.cod_unidade_lotacao_participante)
+            .filter_by(
+                cod_unidade_lotacao=plano_trabalho.cod_unidade_lotacao_participante
+            )
         )
         result = await session.execute(query)
         db_participante = result.scalars().unique().one_or_none()
@@ -236,9 +238,7 @@ async def update_plano_trabalho(
             select(models.PlanoTrabalho)
             .filter_by(origem_unidade=plano_trabalho.origem_unidade)
             .filter_by(cod_unidade_autorizadora=plano_trabalho.cod_unidade_autorizadora)
-            .filter_by(
-                id_plano_trabalho=plano_trabalho.id_plano_trabalho
-            )
+            .filter_by(id_plano_trabalho=plano_trabalho.id_plano_trabalho)
         )
         db_plano_trabalho = result.unique().scalar_one()
         await session.delete(db_plano_trabalho)
@@ -526,10 +526,12 @@ def truncate_plano_trabalho():
     Usado no ambiente de testes de integração contínua.
     """
     with sync_engine.connect() as conn:
-        result = conn.execute(text(
-            "TRUNCATE avaliacao_registros_execucao, contribuicao, "
-            "plano_trabalho CASCADE;"
-        ))
+        result = conn.execute(
+            text(
+                "TRUNCATE avaliacao_registros_execucao, contribuicao, "
+                "plano_trabalho CASCADE;"
+            )
+        )
         conn.commit()
     return result
 

--- a/src/crud.py
+++ b/src/crud.py
@@ -121,15 +121,19 @@ async def create_plano_trabalho(
             com os dados que foram gravados no banco.
     """
     creation_timestamp = datetime.now()
-    contribuicoes = [
-        models.Contribuicao(
-            origem_unidade_pt=plano_trabalho.origem_unidade,
-            cod_unidade_autorizadora_pt=plano_trabalho.cod_unidade_autorizadora,
-            id_plano_trabalho=plano_trabalho.id_plano_trabalho,
-            **contribuicao.model_dump(),
-        )
-        for contribuicao in plano_trabalho.contribuicoes
-    ]
+    contribuicoes = (
+        [
+            models.Contribuicao(
+                origem_unidade_pt=plano_trabalho.origem_unidade,
+                cod_unidade_autorizadora_pt=plano_trabalho.cod_unidade_autorizadora,
+                id_plano_trabalho=plano_trabalho.id_plano_trabalho,
+                **contribuicao.model_dump(),
+            )
+            for contribuicao in plano_trabalho.contribuicoes
+        ]
+        if plano_trabalho.contribuicoes
+        else []
+    )
 
     avaliacoes_registros_execucao = [
         models.AvaliacaoRegistrosExecucao(**avaliacao_registros_execucao.model_dump())

--- a/tests/plano_trabalho/contribuicoes_test.py
+++ b/tests/plano_trabalho/contribuicoes_test.py
@@ -178,6 +178,25 @@ class TestCreatePTNullOptionalFields(BasePTTest):
         assert response.status_code == status.HTTP_201_CREATED
 
 
+class TestCreatePTNullContribuicoes(BasePTTest):
+    """Testa a criação de um novo Plano de Trabalho enviando null na
+    lista de contribuições.
+
+    Verifica se o endpoint de criação de Plano de Trabalho aceita a
+    requisição quando o campos `contribuicoes` é enviado com valor null.
+    """
+
+    def test_create_plano_trabalho_contribuicao_null_optional_fields(
+        self,
+    ):
+        """Tenta criar um novo plano de trabalho enviando null no campo
+        contribuicoes"""
+        input_pt = deepcopy(self.input_pt)
+        input_pt["contribuicoes"] = None
+        response = self.put_plano_trabalho(input_pt)
+        assert response.status_code == status.HTTP_201_CREATED
+
+
 class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
     """Testes relacionados às Contribuições ao criar um Plano de Trabalho."""
 


### PR DESCRIPTION
Fix #152 

Corrige a iteração em lista quando o valor json `null` é passado no campo `contribuicoes` do `plano_trabalho`. Estava gerando erro HTTP 500 para algumas entradas.