### PR TITLE
 Tratar adequadamente quando o valor null é passado em campos opcionais que podem ser listas

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -4,8 +4,8 @@
 ## 3.2.3
 
 * Handle error when submitting a PUT for plano_trabalho with a json
-  value of null for the contribuicoes field. It is now allowed and
-  handled properly (optional field)
+  value of null in the optional fields that are lists. It is now allowed
+  and handled properly
 
 
 ## 3.2.2

--- a/src/crud.py
+++ b/src/crud.py
@@ -121,23 +121,21 @@ async def create_plano_trabalho(
             com os dados que foram gravados no banco.
     """
     creation_timestamp = datetime.now()
-    contribuicoes = (
-        [
-            models.Contribuicao(
-                origem_unidade_pt=plano_trabalho.origem_unidade,
-                cod_unidade_autorizadora_pt=plano_trabalho.cod_unidade_autorizadora,
-                id_plano_trabalho=plano_trabalho.id_plano_trabalho,
-                **contribuicao.model_dump(),
-            )
-            for contribuicao in plano_trabalho.contribuicoes
-        ]
-        if plano_trabalho.contribuicoes
-        else []
-    )
+    contribuicoes = [
+        models.Contribuicao(
+            origem_unidade_pt=plano_trabalho.origem_unidade,
+            cod_unidade_autorizadora_pt=plano_trabalho.cod_unidade_autorizadora,
+            id_plano_trabalho=plano_trabalho.id_plano_trabalho,
+            **contribuicao.model_dump(),
+        )
+        for contribuicao in (plano_trabalho.contribuicoes or [])
+    ]
 
     avaliacoes_registros_execucao = [
         models.AvaliacaoRegistrosExecucao(**avaliacao_registros_execucao.model_dump())
-        for avaliacao_registros_execucao in plano_trabalho.avaliacoes_registros_execucao
+        for avaliacao_registros_execucao in (
+            plano_trabalho.avaliacoes_registros_execucao or []
+        )
     ]
     # Esvazia as listas para poder converter o plano_trabalho para SQL Alchemy
     plano_trabalho.contribuicoes = []

--- a/tests/plano_trabalho/contribuicoes_test.py
+++ b/tests/plano_trabalho/contribuicoes_test.py
@@ -178,25 +178,6 @@ class TestCreatePTNullOptionalFields(BasePTTest):
         assert response.status_code == status.HTTP_201_CREATED
 
 
-class TestCreatePTNullContribuicoes(BasePTTest):
-    """Testa a criação de um novo Plano de Trabalho enviando null na
-    lista de contribuições.
-
-    Verifica se o endpoint de criação de Plano de Trabalho aceita a
-    requisição quando o campos `contribuicoes` é enviado com valor null.
-    """
-
-    def test_create_plano_trabalho_contribuicao_null_optional_fields(
-        self,
-    ):
-        """Tenta criar um novo plano de trabalho enviando null no campo
-        contribuicoes"""
-        input_pt = deepcopy(self.input_pt)
-        input_pt["contribuicoes"] = None
-        response = self.put_plano_trabalho(input_pt)
-        assert response.status_code == status.HTTP_201_CREATED
-
-
 class TestCreatePlanoTrabalhoContribuicoes(BasePTTest):
     """Testes relacionados às Contribuições ao criar um Plano de Trabalho."""
 

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -246,7 +246,9 @@ class TestCreatePlanoTrabalho(BasePTTest):
     @pytest.mark.parametrize(
         "missing_fields", enumerate(FIELDS_PLANO_TRABALHO["mandatory"])
     )
-    def test_create_plano_trabalho_missing_mandatory_fields(self, missing_fields):
+    def test_create_plano_trabalho_missing_mandatory_fields(
+        self, missing_fields: tuple[int, list[str]]
+    ):
         """Tenta criar um plano de trabalho, faltando campos obrigatórios.
         Tem que ser um plano de trabalho novo, pois na atualização de um
         plano de trabalho existente, o campo que ficar faltando será

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -118,7 +118,7 @@ class BasePTTest:
         contribuicoes_1 = set(
             {
                 field: value
-                for contribuicao in plano_trabalho_1["contribuicoes"]
+                for contribuicao in (plano_trabalho_1["contribuicoes"] or [])
                 for field, value in contribuicao.items()
                 if field in FIELDS_CONTRIBUICAO["mandatory"]
             }
@@ -126,7 +126,7 @@ class BasePTTest:
         contribuicoes_2 = set(
             {
                 field: value
-                for contribuicao in plano_trabalho_2["contribuicoes"]
+                for contribuicao in (plano_trabalho_2["contribuicoes"] or [])
                 for field, value in contribuicao.items()
                 if field in FIELDS_CONTRIBUICAO["mandatory"]
             }
@@ -137,7 +137,9 @@ class BasePTTest:
         avaliacao_registros_execucao_1 = set(
             {
                 field: value
-                for avaliacao in plano_trabalho_1["avaliacoes_registros_execucao"]
+                for avaliacao in (
+                    plano_trabalho_1["avaliacoes_registros_execucao"] or []
+                )
                 for field, value in avaliacao.items()
                 if field in FIELDS_AVALIACAO_REGISTROS_EXECUCAO["mandatory"]
             }
@@ -145,7 +147,9 @@ class BasePTTest:
         avaliacao_registros_execucao_2 = set(
             {
                 field: value
-                for avaliacao in plano_trabalho_2["avaliacoes_registros_execucao"]
+                for avaliacao in (
+                    plano_trabalho_2["avaliacoes_registros_execucao"] or []
+                )
                 for field, value in avaliacao.items()
                 if field in FIELDS_AVALIACAO_REGISTROS_EXECUCAO["mandatory"]
             }

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -283,6 +283,29 @@ class TestCreatePlanoTrabalho(BasePTTest):
         # Assert
         assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    @pytest.mark.parametrize(
+        "null_fields", enumerate(FIELDS_PLANO_TRABALHO["optional"])
+    )
+    def test_create_plano_trabalho_null_optional_fields(
+        self, null_fields: tuple[int, list[str]]
+    ):
+        """Tenta criar um plano de trabalho com valores json null nos
+        campos opcionais.
+        """
+        # Arrange
+        offset, field_list = null_fields
+        input_pt = deepcopy(self.input_pt)
+        for field in field_list:
+            input_pt[field] = None
+        input_pt["id_plano_trabalho"] = f"{1900 + offset}"  # precisa ser um novo plano
+
+        # Act
+        response = self.put_plano_trabalho(input_pt)
+
+        # Assert
+        assert response.status_code == status.HTTP_201_CREATED
+        self.assert_equal_plano_trabalho(response.json(), input_pt)
+
     def test_create_pt_cod_plano_inconsistent(self):
         """Tenta criar um plano de trabalho com um códigos diferentes
         informados na URL e no campo id_plano_trabalho do JSON.


### PR DESCRIPTION
Fix #154 

Corrige a iteração em lista quando o valor json `null` é passado em qualquer campo opcional do `plano_trabalho` que pode ser uma lista. Estava gerando erro HTTP 500 para algumas entradas.