### PR TITLE
Solve SQL Alchemy's warnings about absence of PlanoTrabalho in session

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -9,6 +9,8 @@
 * Simplify validation of domain based integers
 * Solve pydantic's warnings about deprecated use of methods .json and
   .dict
+* Solve SQL Alchemy's warnings about absence of PlanoTrabalho in session,
+  in context of the relationship with Participante
 
 
 ## 3.2.3

--- a/src/crud.py
+++ b/src/crud.py
@@ -164,7 +164,8 @@ async def create_plano_trabalho(
                 f"matricula_siape: {plano_trabalho.matricula_siape} "
                 f"cod_unidade_lotacao: {plano_trabalho.cod_unidade_lotacao_participante}"
             )
-        db_plano_trabalho.participante = db_participante
+        session.add(db_participante)
+        db_participante.planos_trabalho.append(db_plano_trabalho)
 
         # Relacionamento com Contribuicao
         for contribuicao in contribuicoes:

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -288,6 +288,7 @@ class TestUpdateParticipante(BaseParticipanteTest):
         input_part = deepcopy(self.input_part)
         response = self.put_participante(input_part)
         assert response.status_code == status.HTTP_200_OK
+        self.assert_equal_participante(response.json(), input_part)
 
     def test_update_participante(
         self,


### PR DESCRIPTION
Fix #140

Solve SQL Alchemy's warnings about absence of PlanoTrabalho in session, in context of the relationship with Participante.