### PR TITLE
Adiciona cabeçalho Content-Security-Policy às páginas de documentação

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -6,6 +6,8 @@
 * Set default access token expiration time to 30 minutes
 * Remove "id" field from Contribuicao's Pydantic schema (there is already
   an "id_contribuicao" field)
+* Add Content-Security-Policy header to API documentation pages (/docs for
+  Swagger UI and /redoc for Redoc)
 
 
 ## 3.2.4

--- a/src/api.py
+++ b/src/api.py
@@ -67,6 +67,13 @@ app = FastAPI(
 async def add_csp_header(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:
+    """Adiciona cabeçalho Content-Security-Policy (CSP), definindo de
+    onde os recursos podem ser carregados pelo navegador, às páginas
+    de documentação (/docs na Swagger UI e /redoc na ReDoc).
+
+    As demais rotas não são feitas para ser acessadas por navegadores e por
+    isso não faz diferença existir CSP.
+    """
     response: Response = await call_next(request)
     if request.url.path.startswith("/docs") or request.url.path.startswith("/redoc"):
         response.headers["Content-Security-Policy"] = "; ".join(

--- a/src/api.py
+++ b/src/api.py
@@ -64,6 +64,26 @@ app = FastAPI(
 
 
 @app.middleware("http")
+async def add_csp_header(
+    request: Request, call_next: Callable[[Request], Awaitable[Response]]
+) -> Response:
+    response: Response = await call_next(request)
+    if request.url.path.startswith("/docs") or request.url.path.startswith("/redoc"):
+        response.headers["Content-Security-Policy"] = "; ".join(
+            [
+                "default-src 'self'",
+                "font-src 'self' fonts.gstatic.com",
+                "media-src 'self' data:",
+                "img-src 'self' data: fastapi.tiangolo.com raw.githubusercontent.com cdn.redoc.ly",
+                "script-src 'self' 'unsafe-inline' cdn.jsdelivr.net",
+                "style-src 'self' 'unsafe-inline' cdn.jsdelivr.net fonts.googleapis.com",
+                "worker-src 'self' blob:",
+            ]
+        )
+    return response
+
+
+@app.middleware("http")
 async def check_user_agent(
     request: Request, call_next: Callable[[Request], Awaitable[Response]]
 ) -> Response:

--- a/src/models.py
+++ b/src/models.py
@@ -165,7 +165,7 @@ class Entrega(Base):
         String,
         index=True,
         nullable=False,
-        comment="Identificador único da entrega",
+        comment="Identificador da entrega",
     )
     entrega_cancelada = Column(
         Boolean,

--- a/tests/endpoints_test.py
+++ b/tests/endpoints_test.py
@@ -31,7 +31,7 @@ def test_redirect_to_entrypoint_json(client: Client):
     assert response.headers["Location"] == "/openapi.json"
 
 
-# Teste de cabeçalho User-Agent
+# Teste de cabeçalhos
 
 
 @pytest.mark.parametrize(
@@ -65,3 +65,23 @@ def test_user_agent_header(
     else:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["detail"] == "User-Agent header is required"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/docs",
+        "/redoc",
+    ],
+)
+def test_docs_csp_header(client: Client, path: str):
+    """Testa a presença do cabeçalho Content-Security-Policy.
+
+    Args:
+        client (Client): fixture do cliente http.
+        path (str): caminho da URL a testar.
+    """
+    response = client.get(path, headers={"Accept": "text/html"})
+
+    assert response.status_code == status.HTTP_200_OK
+    assert response.headers.get("Content-Security-Policy", None) is not None


### PR DESCRIPTION
Adiciona cabeçalho [Content-Security-Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy) (CSP), definindo de onde os recursos podem ser carregados pelo navegador, às páginas de documentação (`/docs` na Swagger UI e `/redoc` na ReDoc).

As demais rotas não são feitas para ser acessadas por navegadores e por isso não faz diferença existir CSP.

Fix #144