### PR TITLE
Add validation for `data_inicio` of `PlanoTrabalho`, must be equal to or greater than `data_assinatura_tcr` of Participante

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -1,5 +1,11 @@
 # Release notes
 
+## 3.2.8
+
+* Add folder for schema migration scripts
+* Add validation rule for `data_inicio` and `data_assinatura_tcr` in
+  `PlanoTrabalhoSchema`
+
 
 ## 3.2.7
 

--- a/src/crud.py
+++ b/src/crud.py
@@ -158,11 +158,18 @@ async def create_plano_trabalho(
         db_participante = result.scalars().unique().one_or_none()
         if db_participante is None:
             raise ValueError(
-                "Plano de Trabalho faz referência a participante inexistente. "
-                f"origem_unidade: {plano_trabalho.origem_unidade} "
-                f"cod_unidade_autorizadora: {plano_trabalho.cod_unidade_autorizadora} "
-                f"matricula_siape: {plano_trabalho.matricula_siape} "
-                f"cod_unidade_lotacao: {plano_trabalho.cod_unidade_lotacao_participante}"
+                "Plano de Trabalho faz referência a participante inexistente.\n"
+                f" origem_unidade: {plano_trabalho.origem_unidade}\n"
+                f" cod_unidade_autorizadora: {plano_trabalho.cod_unidade_autorizadora}\n"
+                f" matricula_siape: {plano_trabalho.matricula_siape}\n"
+                f" cod_unidade_lotacao: {plano_trabalho.cod_unidade_lotacao_participante}"
+            )
+        if plano_trabalho.data_inicio < db_participante.data_assinatura_tcr:
+            raise ValueError(
+                "data_inicio do Plano de Trabalho deve ser maior ou igual à "
+                "data_assinatura_tcr do Participante.\n"
+                f" data_inicio: {plano_trabalho.data_inicio}\n"
+                f" data_assinatura_tcr: {db_participante.data_assinatura_tcr}"
             )
         session.add(db_participante)
         db_participante.planos_trabalho.append(db_plano_trabalho)

--- a/src/models.py
+++ b/src/models.py
@@ -347,8 +347,8 @@ class PlanoTrabalho(Base):
         Date,
         nullable=False,
         comment="Data de início do plano de trabalho do participante. "
-        "\n\n**Regras de validação:** deve ser posterior à “data_assinatura_tcr”"
-        "e à “data_inicio” do “plano_entregas”.",
+        "\n\n**Regras de validação:** deve ser igual ou posterior à "
+        "“data_assinatura_tcr” e à “data_inicio” do “plano_entregas”.",
     )
     data_termino = Column(
         Date,
@@ -683,7 +683,9 @@ class Participante(Base):
         "enviar `date`**, uma vez que *a hora é ignorada* e não é armazenada. O "
         "formato `datetime`é aceito apenas por compatibilidade com versões "
         "anteriores da API, que o aceitavam. Em versões futuras essa "
-        "flexibilidade será retirada.",
+        "flexibilidade será retirada.\n\n"
+        "A data informada deve permanecer a data original, mesmo em caso de "
+        "haver repactuação.",
     )
     data_atualizacao = Column(DateTime)
     data_insercao = Column(DateTime, nullable=False)

--- a/tests/data/plano_trabalho.json
+++ b/tests/data/plano_trabalho.json
@@ -7,8 +7,8 @@
     "cpf_participante": "64635210600",
     "matricula_siape": "1237654",
     "cod_unidade_lotacao_participante": 99,
-    "data_inicio": "2023-01-01",
-    "data_termino": "2023-01-15",
+    "data_inicio": "2023-06-01",
+    "data_termino": "2023-06-15",
     "carga_horaria_disponivel": 80,
     "contribuicoes": [
         {
@@ -29,10 +29,10 @@
     "avaliacoes_registros_execucao": [
         {
             "id_periodo_avaliativo": "5551",
-            "data_inicio_periodo_avaliativo": "2023-01-01",
-            "data_fim_periodo_avaliativo": "2023-01-02",
+            "data_inicio_periodo_avaliativo": "2023-06-01",
+            "data_fim_periodo_avaliativo": "2023-06-02",
             "avaliacao_registros_execucao": 5,
-            "data_avaliacao_registros_execucao": "2023-01-03",
+            "data_avaliacao_registros_execucao": "2023-06-03",
             "cpf_participante": "64635210600"
         }
     ]

--- a/tests/data/plano_trabalho.json
+++ b/tests/data/plano_trabalho.json
@@ -32,7 +32,7 @@
             "data_inicio_periodo_avaliativo": "2023-06-01",
             "data_fim_periodo_avaliativo": "2023-06-02",
             "avaliacao_registros_execucao": 5,
-            "data_avaliacao_registros_execucao": "2023-06-03",
+            "data_avaliacao_registros_execucao": "2023-06-10",
             "cpf_participante": "64635210600"
         }
     ]

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -509,7 +509,7 @@ class TestUpdatePlanoDeTrabalho(BasePTTest):
 
         input_pt = deepcopy(self.input_pt)
         input_pt["status"] = 4  # Valor era 3
-        input_pt["data_termino"] = "2023-01-31"  # Valor era "2023-01-15"
+        input_pt["data_termino"] = "2023-06-30"  # Valor era "2023-06-15"
         response = self.put_plano_trabalho(input_pt)
         assert response.status_code == status.HTTP_200_OK
         self.assert_equal_plano_trabalho(response.json(), input_pt)

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -472,7 +472,7 @@ class TestCreatePlanoTrabalho(BasePTTest):
 
         if all(
             (
-                (0 < input_pt.get(field) <= MAX_INT)
+                (0 < input_pt.get(field, 0) <= MAX_INT)
                 for field in (
                     "cod_unidade_autorizadora",
                     "cod_unidade_executora",

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -131,28 +131,28 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 "101",
                 99,
                 "1237654",
-                "2023-01-01",
-                "2023-01-15",
+                "2023-06-01",
+                "2023-06-15",
                 2,
             ),  # igual ao exemplo
             (
                 "102",
                 99,
                 "1237654",
-                "2023-02-01",
-                "2023-02-15",
+                "2023-07-01",
+                "2023-07-15",
                 2,
             ),  # sem sobreposição
             # sobreposição no início
-            ("103", 99, "1237654", "2022-12-01", "2023-01-08", 2),
+            ("103", 99, "1237654", "2022-12-01", "2023-06-08", 2),
             # sobreposição no fim
-            ("104", 99, "1237654", "2023-01-30", "2023-02-15", 2),
+            ("104", 99, "1237654", "2023-06-30", "2023-07-15", 2),
             (
                 "105",
                 99,
                 "1237654",
-                "2023-01-02",
-                "2023-01-08",
+                "2023-06-02",
+                "2023-06-08",
                 2,
             ),  # contido no período
             (
@@ -160,16 +160,16 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 99,
                 "1237654",
                 "2022-12-31",
-                "2023-01-16",
+                "2023-06-16",
                 2,
             ),  # contém o período
-            ("107", 99, "1237654", "2022-12-01", "2023-01-08", 1),  # cancelado
+            ("107", 99, "1237654", "2022-12-01", "2023-06-08", 1),  # cancelado
             (
                 "109",
                 100,
                 "1234567",
-                "2023-01-01",
-                "2023-01-15",
+                "2023-06-01",
+                "2023-06-15",
                 2,
             ),  # outro participante
         ],
@@ -197,15 +197,15 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
         original_pt = input_pt.copy()
         input_pt2 = original_pt.copy()
         input_pt2["id_plano_trabalho"] = "556"
-        input_pt2["data_inicio"] = "2023-01-16"
-        input_pt2["data_termino"] = "2023-01-31"
+        input_pt2["data_inicio"] = "2023-06-16"
+        input_pt2["data_termino"] = "2023-06-30"
         input_pt2["avaliacoes_registros_execucao"] = [
             {
                 "id_periodo_avaliativo": "string",
-                "data_inicio_periodo_avaliativo": "2023-01-16",
-                "data_fim_periodo_avaliativo": "2023-01-23",
+                "data_inicio_periodo_avaliativo": "2023-06-16",
+                "data_fim_periodo_avaliativo": "2023-06-23",
                 "avaliacao_registros_execucao": 5,
-                "data_avaliacao_registros_execucao": "2023-01-23",
+                "data_avaliacao_registros_execucao": "2023-06-23",
                 "matricula_siape": "1237654",
                 "carga_horaria_disponivel": 80,
             }
@@ -330,10 +330,10 @@ class TestCreatePTDataAvaliacao(BasePTTest):
         "id_plano_trabalho, data_inicio_periodo_avaliativo, "
         "data_fim_periodo_avaliativo, data_avaliacao_registros_execucao",
         [
-            ("80", "2023-04-01", "2023-04-10", "2023-03-31"),  # antes do início
-            ("81", "2023-04-01", "2023-04-10", "2023-04-01"),  # igual ao início
-            ("82", "2023-04-01", "2023-04-10", "2023-04-05"),  # depois do início
-            ("83", "2023-04-01", "2023-04-10", "2023-04-15"),  # depois do fim
+            ("80", "2023-06-02", "2023-06-10", "2023-06-01"),  # antes do início
+            ("81", "2023-06-01", "2023-06-10", "2023-06-01"),  # igual ao início
+            ("82", "2023-06-01", "2023-06-10", "2023-06-05"),  # depois do início
+            ("83", "2023-06-01", "2023-06-10", "2023-06-15"),  # depois do fim
         ],
     )
     def test_create_pt_data_avaliacao_out_of_bounds(
@@ -384,34 +384,34 @@ class TestCreatePlanoDeTrabalhoPeriodoAvaliativoOverlapping(BasePTTest):
     @pytest.mark.parametrize(
         "id_plano_trabalho, periodo_avaliativo",
         [
-            ("101", [("2023-01-01", "2023-01-02")]),  # igual ao exemplo
+            ("101", [("2023-06-01", "2023-06-02")]),  # igual ao exemplo
             (
                 "102",
-                [("2023-01-01", "2023-01-07"), ("2023-01-08", "2023-01-15")],
+                [("2023-06-01", "2023-06-07"), ("2023-06-08", "2023-06-15")],
             ),  # sem sobreposição
             (
                 "103",
-                [("2023-01-07", "2023-01-15"), ("2023-01-01", "2023-01-07")],
+                [("2023-06-07", "2023-06-15"), ("2023-06-01", "2023-06-07")],
             ),  # sobreposição no início
             (
                 "104",
-                [("2023-01-01", "2023-01-08"), ("2023-01-07", "2023-01-15")],
+                [("2023-06-01", "2023-06-08"), ("2023-06-07", "2023-06-15")],
             ),  # sobreposição no fim
             (
                 "105",
                 [
-                    ("2023-01-01", "2023-01-06"),
-                    ("2023-01-06", "2023-01-11"),
-                    ("2023-01-11", "2023-01-15"),
+                    ("2023-06-01", "2023-06-06"),
+                    ("2023-06-06", "2023-06-11"),
+                    ("2023-06-11", "2023-06-15"),
                 ],
             ),  # sobreposições múltiplas
             (
                 "106",
-                [("2023-01-01", "2023-01-14"), ("2023-01-02", "2023-01-13")],
+                [("2023-06-01", "2023-06-14"), ("2023-06-02", "2023-06-13")],
             ),  # contido no período
             (
                 "107",
-                [("2023-01-02", "2023-01-14"), ("2023-01-01", "2023-01-15")],
+                [("2023-06-02", "2023-06-14"), ("2023-06-01", "2023-06-15")],
             ),  # contém o período
         ],
     )

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -76,9 +76,9 @@ class TestCreatePTDateIntervalOverAYear(BasePTTest):
     @pytest.mark.parametrize(
         "data_inicio, data_termino",
         [
-            ("2023-01-01", "2023-06-30"),  # igual ao exemplo
-            ("2023-01-01", "2024-01-01"),  # um ano
-            ("2023-01-01", "2024-01-02"),  # mais que um ano
+            ("2023-06-01", "2023-06-30"),  # igual ao exemplo
+            ("2023-06-01", "2024-06-01"),  # um ano
+            ("2023-06-01", "2024-06-02"),  # mais que um ano
         ],
     )
     def test_create_plano_trabalho_date_interval_over_a_year(
@@ -120,7 +120,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 "101",
                 99,
                 "1237654",
-                "2023-06-01",
+                "2023-06-08",
                 "2023-06-15",
                 2,
             ),  # igual ao exemplo
@@ -133,26 +133,26 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
                 2,
             ),  # sem sobreposição
             # sobreposição no início
-            ("103", 99, "1237654", "2022-12-01", "2023-06-08", 2),
+            ("103", 99, "1237654", "2023-06-01", "2023-06-08", 2),
             # sobreposição no fim
-            ("104", 99, "1237654", "2023-06-30", "2023-07-15", 2),
+            ("104", 99, "1237654", "2023-06-15", "2023-07-15", 2),
             (
                 "105",
                 99,
                 "1237654",
-                "2023-06-02",
-                "2023-06-08",
+                "2023-06-09",
+                "2023-06-10",
                 2,
             ),  # contido no período
             (
                 "106",
                 99,
                 "1237654",
-                "2022-12-31",
+                "2023-06-07",
                 "2023-06-16",
                 2,
             ),  # contém o período
-            ("107", 99, "1237654", "2022-12-01", "2023-06-08", 1),  # cancelado
+            ("107", 99, "1237654", "2023-06-01", "2023-06-30", 1),  # cancelado
             (
                 "109",
                 100,
@@ -183,6 +183,7 @@ class TestCreatePTOverlappingDateInterval(BasePTTest):
         especificado nos parâmetros de teste.
         """
         input_pt = deepcopy(self.input_pt)
+        input_pt["data_inicio"] = "2023-06-08"
         original_pt = input_pt.copy()
         input_pt2 = original_pt.copy()
         input_pt2["id_plano_trabalho"] = "556"
@@ -265,11 +266,11 @@ class TestCreatePTDataAvaliacao(BasePTTest):
         "data_fim_periodo_avaliativo",
         [
             # período inteiro antes da data_inicio do Plano de Trabalho
-            ("80", "2022-12-30", "2022-12-31"),
+            ("80", "2023-06-01", "2023-06-07"),
             # fim antes do início
-            ("81", "2022-12-31", "2022-12-30"),
+            ("81", "2023-06-11", "2022-06-10"),
             # início igual à data_inicio do Plano de Trabalho
-            ("82", "2023-01-01", "2023-01-02"),
+            ("82", "2023-06-08", "2023-06-09"),
         ],
     )
     def test_create_pt_invalid_periodo_avaliativo(
@@ -284,6 +285,7 @@ class TestCreatePTDataAvaliacao(BasePTTest):
         - começa, no mínio, na data de início do Plano de Trabalho.
         """
         input_pt = deepcopy(self.input_pt)
+        input_pt["data_inicio"] = "2023-06-08"
         input_pt["id_plano_trabalho"] = id_plano_trabalho
         input_pt["avaliacoes_registros_execucao"][0][
             "data_inicio_periodo_avaliativo"


### PR DESCRIPTION
Fix #183

Validation rule requested by stakeholder.