### PR TITLE
Remove data_assinatura_tcr validation (greater than data_inicio of Plano de Trabalho)

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -164,13 +164,6 @@ async def create_plano_trabalho(
                 f" matricula_siape: {plano_trabalho.matricula_siape}\n"
                 f" cod_unidade_lotacao: {plano_trabalho.cod_unidade_lotacao_participante}"
             )
-        if plano_trabalho.data_inicio < db_participante.data_assinatura_tcr:
-            raise ValueError(
-                "data_inicio do Plano de Trabalho deve ser maior ou igual à "
-                "data_assinatura_tcr do Participante.\n"
-                f" data_inicio: {plano_trabalho.data_inicio}\n"
-                f" data_assinatura_tcr: {db_participante.data_assinatura_tcr}"
-            )
         session.add(db_participante)
         db_participante.planos_trabalho.append(db_plano_trabalho)
 

--- a/src/models.py
+++ b/src/models.py
@@ -348,7 +348,7 @@ class PlanoTrabalho(Base):
         nullable=False,
         comment="Data de início do plano de trabalho do participante. "
         "\n\n**Regras de validação:** deve ser igual ou posterior à "
-        "“data_assinatura_tcr” e à “data_inicio” do “plano_entregas”.",
+        "“data_inicio” do “plano_entregas”.",
     )
     data_termino = Column(
         Date,

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -20,15 +20,7 @@ class TestCreatePTInvalidDates(BasePTTest):
 
     @pytest.mark.parametrize(
         ("data_inicio, data_termino"),
-        # data presente no example_part:
-        # "data_assinatura_tcr": "2023-06-01"
         [
-            # data_inicio anterior à data_assinatura_tcr (inválida)
-            (date(2023, 5, 1), date(2023, 7, 1)),
-            # data_inicio igual à data_assinatura_tcr (válida)
-            (date(2023, 6, 1), date(2023, 7, 1)),
-            # data_inicio posterior à data_assinatura_tcr (válida)
-            (date(2023, 7, 1), date(2023, 8, 1)),
             # data_inicio posterior à data_termino (inválida)
             (date(2023, 7, 1), date(2023, 6, 1)),
         ],
@@ -56,13 +48,6 @@ class TestCreatePTInvalidDates(BasePTTest):
             detail_message = (
                 "data_termino do Plano de Trabalho deve ser maior ou igual "
                 "que data_inicio"
-            )
-            assert_error_message(response, detail_message)
-        elif data_inicio < date.fromisoformat(input_part["data_assinatura_tcr"]):
-            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-            detail_message = (
-                "data_inicio do Plano de Trabalho deve ser maior ou igual à "
-                "data_assinatura_tcr do Participante"
             )
             assert_error_message(response, detail_message)
         else:


### PR DESCRIPTION
- Remove validation on CRUD (if data_assinatura_tcr > data_inicio)
- Adjust field description on models
- Remove data_assinatura_tcr fixture and validation on Plano de Trabalho tests