### PR TITLE
Remove flag reload on image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ COPY src/ src/
 
 EXPOSE 5057
 
-ENTRYPOINT ["sh", "-c", "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057 --reload"]
+ENTRYPOINT ["sh", "-c", "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
   api-pgd:
     image: ghcr.io/gestaogovbr/api-pgd:latest
     container_name: api-pgd
+    entrypoint: ["sh",
+                 "-c",
+                 "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057 --reload",
+                ]
     depends_on:
       db:
         condition: service_healthy

--- a/src/models.py
+++ b/src/models.py
@@ -224,7 +224,7 @@ class Entrega(Base):
         comment="origem_unidade do Plano de Entregas (FK)",
     )
     cod_unidade_autorizadora = Column(
-        Integer,
+        BigInteger,
         nullable=False,
         comment="cod_unidade_autorizadora do Plano de Entregas (FK)",
     )
@@ -335,7 +335,7 @@ class PlanoTrabalho(Base):
         "Administração de Recursos Humanos (SIAPE).",
     )
     cod_unidade_lotacao_participante = Column(
-        Integer,
+        BigInteger,
         nullable=False,
         comment="Código da unidade organizacional (UORG) no Sistema Integrado de "
         "Administração de Recursos Humanos (SIAPE) corresponde à unidade de "
@@ -357,7 +357,7 @@ class PlanoTrabalho(Base):
         "\n\n**Regras de validação:** deve ser posterior à “data_inicio”.",
     )
     carga_horaria_disponivel = Column(
-        Integer,
+        BigInteger,
         nullable=False,
         comment="Carga horária total do participante disponível no período de "
         "vigência do plano de trabalho. Não inclui períodos de férias, "
@@ -475,7 +475,7 @@ class Contribuicao(Base):
         "ao Plano de Trabalho. (FK)",
     )
     cod_unidade_autorizadora_pt = Column(
-        Integer,
+        BigInteger,
         nullable=False,
         comment="cod_unidade_autorizadora do Plano de Trabalho (FK)",
     )
@@ -571,7 +571,7 @@ class AvaliacaoRegistrosExecucao(Base):
         "ao Plano de Trabalho. (FK)",
     )
     cod_unidade_autorizadora_pt = Column(
-        Integer,
+        BigInteger,
         nullable=False,
         comment="cod_unidade_autorizadora do Plano de Trabalho (FK)",
     )

--- a/src/models.py
+++ b/src/models.py
@@ -357,7 +357,7 @@ class PlanoTrabalho(Base):
         "\n\n**Regras de validação:** deve ser posterior à “data_inicio”.",
     )
     carga_horaria_disponivel = Column(
-        BigInteger,
+        Integer,
         nullable=False,
         comment="Carga horária total do participante disponível no período de "
         "vigência do plano de trabalho. Não inclui períodos de férias, "

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -27,6 +27,8 @@ from models import (
 from util import over_a_year
 
 STR_FIELD_MAX_SIZE = 300
+NON_NEGATIVE_INT4 = Annotated[NonNegativeInt, Field(le=(2**31) - 1)]
+POSITIVE_INT4 = Annotated[PositiveInt, Field(le=(2**31) - 1)]
 NON_NEGATIVE_INT8 = Annotated[NonNegativeInt, Field(le=(2**63) - 1)]
 POSITIVE_INT8 = Annotated[PositiveInt, Field(le=(2**63) - 1)]
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -27,8 +27,8 @@ from models import (
 from util import over_a_year
 
 STR_FIELD_MAX_SIZE = 300
-NON_NEGATIVE_INT4 = Annotated[NonNegativeInt, Field(le=(2**31) - 1)]
-POSITIVE_INT4 = Annotated[PositiveInt, Field(le=(2**31) - 1)]
+NON_NEGATIVE_INT8 = Annotated[NonNegativeInt, Field(le=(2**63) - 1)]
+POSITIVE_INT8 = Annotated[PositiveInt, Field(le=(2**63) - 1)]
 
 # Funções auxiliares
 
@@ -247,7 +247,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Origem da unidade",
         description=PlanoTrabalho.origem_unidade.comment,
     )
-    cod_unidade_autorizadora: POSITIVE_INT4 = Field(
+    cod_unidade_autorizadora: POSITIVE_INT8 = Field(
         title="Código da unidade autorizadora",
         description=PlanoTrabalho.cod_unidade_autorizadora.comment,
     )
@@ -259,7 +259,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Status do plano de trabalho",
         description=PlanoTrabalho.status.comment,
     )
-    cod_unidade_executora: POSITIVE_INT4 = Field(
+    cod_unidade_executora: POSITIVE_INT8 = Field(
         title="Código da unidade executora",
         description=PlanoTrabalho.cod_unidade_executora.comment,
     )
@@ -277,7 +277,7 @@ class PlanoTrabalhoSchema(BaseModel):
         max_length=7,
         pattern=r"\d{7}",
     )
-    cod_unidade_lotacao_participante: POSITIVE_INT4 = Field(
+    cod_unidade_lotacao_participante: POSITIVE_INT8 = Field(
         title="Código da unidade lotacao participante",
         description=PlanoTrabalho.cod_unidade_lotacao_participante.comment,
     )
@@ -289,7 +289,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Data de término do plano de trabalho",
         description=PlanoTrabalho.data_termino.comment,
     )
-    carga_horaria_disponivel: NON_NEGATIVE_INT4 = Field(
+    carga_horaria_disponivel: NON_NEGATIVE_INT8 = Field(
         title="Carga horária disponível do participante",
         description=PlanoTrabalho.carga_horaria_disponivel.comment,
     )
@@ -443,15 +443,15 @@ class PlanoEntregasSchema(BaseModel):
         title="Código do sistema da unidade",
         description=PlanoEntregas.origem_unidade.comment,
     )
-    cod_unidade_autorizadora: POSITIVE_INT4 = Field(
+    cod_unidade_autorizadora: POSITIVE_INT8 = Field(
         title="Código da unidade autorizadora",
         description=PlanoEntregas.cod_unidade_autorizadora.comment,
     )
-    cod_unidade_instituidora: POSITIVE_INT4 = Field(
+    cod_unidade_instituidora: POSITIVE_INT8 = Field(
         title="Código da unidade instituidora",
         description=PlanoEntregas.cod_unidade_instituidora.comment,
     )
-    cod_unidade_executora: POSITIVE_INT4 = Field(
+    cod_unidade_executora: POSITIVE_INT8 = Field(
         title="Código da unidade executora",
         description=PlanoEntregas.cod_unidade_executora.comment,
     )
@@ -525,11 +525,11 @@ class ParticipanteSchema(BaseModel):
         title="Código do sistema da unidade (SIAPE ou SIORG)",
         description=Participante.origem_unidade.comment,
     )
-    cod_unidade_autorizadora: NON_NEGATIVE_INT4 = Field(
+    cod_unidade_autorizadora: NON_NEGATIVE_INT8 = Field(
         title="Código da unidade organizacional autorizadora do PGD",
         description=Participante.cod_unidade_autorizadora.comment,
     )
-    cod_unidade_lotacao: NON_NEGATIVE_INT4 = Field(
+    cod_unidade_lotacao: NON_NEGATIVE_INT8 = Field(
         title="Código da unidade organizacional de lotação do participante",
         description=Participante.cod_unidade_lotacao.comment,
     )
@@ -540,7 +540,7 @@ class ParticipanteSchema(BaseModel):
         max_length=7,
         pattern=r"\d{7}",
     )
-    cod_unidade_instituidora: NON_NEGATIVE_INT4 = Field(
+    cod_unidade_instituidora: NON_NEGATIVE_INT8 = Field(
         title="Código da unidade organizacional instituidora do PGD",
         description=Participante.cod_unidade_instituidora.comment,
     )

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -291,7 +291,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Data de término do plano de trabalho",
         description=PlanoTrabalho.data_termino.comment,
     )
-    carga_horaria_disponivel: NON_NEGATIVE_INT8 = Field(
+    carga_horaria_disponivel: NON_NEGATIVE_INT4 = Field(
         title="Carga horária disponível do participante",
         description=PlanoTrabalho.carga_horaria_disponivel.comment,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,7 @@ API_BASE_URL = "http://localhost:5057"
 
 TEST_USER_AGENT = "API PGD CI Test (+https://github.com/gestaogovbr/api-pgd)"
 
-MAX_INT = (2**31) - 1
+MAX_INT = (2**63) - 1
 
 
 def get_bearer_token(username: str, password: str) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,7 +409,7 @@ def example_pe_max_int(
     """Cria um Plano de Entrega como exemplo usando o valor máximo
     permitido para cod_unidade_autorizadora."""
     new_input_pe = deepcopy(input_pe)
-    new_input_pe["cod_unidade_autorizadora"] = MAX_INT
+    new_input_pe["cod_unidade_autorizadora"] = MAX_BIGINT
     client.put(
         f"/organizacao/SIAPE/{new_input_pe['cod_unidade_autorizadora']}"
         f"/plano_entregas/{new_input_pe['id_plano_entregas']}",
@@ -499,7 +499,7 @@ def example_part_max_int(client: httpx.Client, input_part: dict, header_admin: d
     """Cria exemplos de participantes com as combinações de códigos de
     unidade usando os inteiros máximos permitidos para os tipos de campo."""
     new_input_part = deepcopy(input_part)
-    new_input_part["cod_unidade_lotacao"] = MAX_INT
+    new_input_part["cod_unidade_lotacao"] = MAX_BIGINT
     client.put(
         f"/organizacao/{new_input_part['origem_unidade']}"
         f"/{new_input_part['cod_unidade_autorizadora']}"
@@ -509,7 +509,7 @@ def example_part_max_int(client: httpx.Client, input_part: dict, header_admin: d
         headers=header_admin,
     )
     new_input_part["cod_unidade_lotacao"] = input_part["cod_unidade_lotacao"]
-    new_input_part["cod_unidade_autorizadora"] = MAX_INT
+    new_input_part["cod_unidade_autorizadora"] = MAX_BIGINT
     client.put(
         f"/organizacao/{new_input_part['origem_unidade']}"
         f"/{new_input_part['cod_unidade_autorizadora']}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,8 @@ API_BASE_URL = "http://localhost:5057"
 
 TEST_USER_AGENT = "API PGD CI Test (+https://github.com/gestaogovbr/api-pgd)"
 
-MAX_INT = (2**63) - 1
+MAX_INT = (2**31) - 1
+MAX_BIGINT = (2**63) - 1
 
 
 def get_bearer_token(username: str, password: str) -> str:

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -10,7 +10,7 @@ from fastapi import status
 from httpx import Client, Response
 import pytest
 
-from .conftest import MAX_INT
+from .conftest import MAX_BIGINT
 
 # Relação de campos obrigatórios para testar sua ausência:
 FIELDS_PARTICIPANTES = {
@@ -233,12 +233,12 @@ class TestCreateParticipante(BaseParticipanteTest):
             (-1, 1, 99),  # cod_unidade_autorizadora negativo
             (1, -1, 99),  # cod_unidade_instituidora negativo
             (1, 1, -1),  # cod_unidade_lotacao negativo
-            (MAX_INT + 1, 1, 99),  # cod_unidade_autorizadora maior que MAX_INT
-            (1, MAX_INT + 1, 99),  # cod_unidade_instituidora maior que MAX_INT
-            (1, 1, MAX_INT + 1),  # cod_unidade_lotacao maior que MAX_INT
-            (MAX_INT, 1, 99),  # cod_unidade_autorizadora igual a MAX_INT
-            (1, MAX_INT, 99),  # cod_unidade_instituidora igual a MAX_INT
-            (1, 1, MAX_INT),  # cod_unidade_lotacao igual a MAX_INT
+            (MAX_BIGINT + 1, 1, 99),  # cod_unidade_autorizadora maior que MAX_BIGINT
+            (1, MAX_BIGINT + 1, 99),  # cod_unidade_instituidora maior que MAX_BIGINT
+            (1, 1, MAX_BIGINT + 1),  # cod_unidade_lotacao maior que MAX_BIGINT
+            (MAX_BIGINT, 1, 99),  # cod_unidade_autorizadora igual a MAX_BIGINT
+            (1, MAX_BIGINT, 99),  # cod_unidade_instituidora igual a MAX_BIGINT
+            (1, 1, MAX_BIGINT),  # cod_unidade_lotacao igual a MAX_BIGINT
         ],
     )
     def test_create_participante_unit_out_of_range(
@@ -259,7 +259,7 @@ class TestCreateParticipante(BaseParticipanteTest):
 
         if all(
             (
-                (0 < input_part.get(field) <= MAX_INT)
+                (0 < input_part.get(field) <= MAX_BIGINT)
                 for field in (
                     "cod_unidade_autorizadora",
                     "cod_unidade_instituidora",

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -11,7 +11,7 @@ from fastapi import status as http_status
 import pytest
 
 from util import assert_error_message
-from ..conftest import MAX_INT
+from ..conftest import MAX_BIGINT
 
 # constantes
 
@@ -608,12 +608,12 @@ class TestCreatePEInputValidation(BasePETest):
             (-1, 99, 99),  # cod_unidade_autorizadora negativo
             (1, -1, 99),  # cod_unidade_instituidora negativo
             (1, 99, -1),  # cod_unidade_executora negativo
-            (MAX_INT, 99, 99),  # cod_unidade_autorizadora igual a MAX_INT
-            (1, MAX_INT, 99),  # cod_unidade_instituidora igual a MAX_INT
-            (1, 99, MAX_INT),  # cod_unidade_executora igual a MAX_INT
-            (MAX_INT + 1, 99, 99),  # cod_unidade_autorizadora maior que MAX_INT
-            (1, MAX_INT + 1, 99),  # cod_unidade_instituidora maior que MAX_INT
-            (1, 99, MAX_INT + 1),  # cod_unidade_executora maior que MAX_INT
+            (MAX_BIGINT, 99, 99),  # cod_unidade_autorizadora igual a MAX_BIGINT
+            (1, MAX_BIGINT, 99),  # cod_unidade_instituidora igual a MAX_BIGINT
+            (1, 99, MAX_BIGINT),  # cod_unidade_executora igual a MAX_BIGINT
+            (MAX_BIGINT + 1, 99, 99),  # cod_unidade_autorizadora maior que MAX_BIGINT
+            (1, MAX_BIGINT + 1, 99),  # cod_unidade_instituidora maior que MAX_BIGINT
+            (1, 99, MAX_BIGINT + 1),  # cod_unidade_executora maior que MAX_BIGINT
         ],
     )
     def test_create_plano_entregas_int_out_of_range(
@@ -636,7 +636,7 @@ class TestCreatePEInputValidation(BasePETest):
 
         if all(
             (
-                (0 < input_pe.get(field) <= MAX_INT)
+                (0 < input_pe.get(field) <= MAX_BIGINT)
                 for field in (
                     "cod_unidade_autorizadora",
                     "cod_unidade_instituidora",

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -12,7 +12,7 @@ from fastapi import status
 import pytest
 
 from util import assert_error_message
-from ..conftest import MAX_INT
+from ..conftest import MAX_INT, MAX_BIGINT
 
 
 # grupos de campos opcionais e obrigatórios a testar
@@ -440,13 +440,18 @@ class TestCreatePlanoTrabalho(BasePTTest):
             (1, -1, 99, 80),  # cod_unidade_executora negativo
             (1, 99, -1, 80),  # cod_unidade_lotacao_participante negativo
             (1, 99, 99, -80),  # carga_horaria_disponivel negativo
-            (MAX_INT + 1, 1, 99, 80),  # cod_unidade_autorizadora maior que MAX_INT
-            (1, MAX_INT + 1, 99, 80),  # cod_unidade_executora maior que MAX_INT
-            (1, 99, MAX_INT + 1, 80),  # cod_unidade_lotacao maior que MAX_INT
+            (
+                MAX_BIGINT + 1,
+                1,
+                99,
+                80,
+            ),  # cod_unidade_autorizadora maior que MAX_BIGINT
+            (1, MAX_BIGINT + 1, 99, 80),  # cod_unidade_executora maior que MAX_BIGINT
+            (1, 99, MAX_BIGINT + 1, 80),  # cod_unidade_lotacao maior que MAX_BIGINT
             (1, 99, 99, MAX_INT + 1),  # carga_horaria_disponivel maior que MAX_INT
-            (MAX_INT, 1, 99, 80),  # cod_unidade_autorizadora igual a MAX_INT
-            (1, MAX_INT, 99, 80),  # cod_unidade_executora igual a MAX_INT
-            (1, 99, MAX_INT, 80),  # cod_unidade_lotacao igual a MAX_INT
+            (MAX_BIGINT, 1, 99, 80),  # cod_unidade_autorizadora igual a MAX_BIGINT
+            (1, MAX_BIGINT, 99, 80),  # cod_unidade_executora igual a MAX_BIGINT
+            (1, 99, MAX_BIGINT, 80),  # cod_unidade_lotacao igual a MAX_BIGINT
             (1, 99, 99, MAX_INT),  # carga_horaria_disponivel igual a MAX_INT
         ],
     )
@@ -471,15 +476,13 @@ class TestCreatePlanoTrabalho(BasePTTest):
         response = self.put_plano_trabalho(input_pt)
 
         if all(
-            (
-                (0 < input_pt.get(field, 0) <= MAX_INT)
-                for field in (
-                    "cod_unidade_autorizadora",
-                    "cod_unidade_executora",
-                    "cod_unidade_lotacao_participante",
-                    "carga_horaria_disponivel",
-                )
-            )
+            (0 < input_pt.get(field, 0) <= max_value)
+            for field, max_value in {
+                "cod_unidade_autorizadora": MAX_BIGINT,
+                "cod_unidade_executora": MAX_BIGINT,
+                "cod_unidade_lotacao_participante": MAX_BIGINT,
+                "carga_horaria_disponivel": MAX_INT,
+            }.items()
         ):
             assert response.status_code == status.HTTP_201_CREATED
         else:


### PR DESCRIPTION
- Remove flag --reload on docker build process.
- Override entrypoint on docker-compose file adding flag --reload, for local development. When using docker-compose up, it will override the entrypoint defined in the Dockerfile.

fix #182 