### PR TITLE
Remove flag reload on image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,5 +26,5 @@ COPY src/ src/
 
 EXPOSE 5057
 
-ENTRYPOINT ["sh", "-c", "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057 --reload"]
+ENTRYPOINT ["sh", "-c", "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057"]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,10 @@ services:
   api-pgd:
     image: ghcr.io/gestaogovbr/api-pgd:latest
     container_name: api-pgd
+    entrypoint: ["sh",
+                  "-c",
+                  "cd /api-pgd/src && uvicorn api:app --host 0.0.0.0 --port 5057 --reload",
+                  ]
     depends_on:
       db:
         condition: service_healthy


### PR DESCRIPTION
- Remove flag _--reload_ on docker build process.
- Override entrypoint on docker-compose file adding flag _--reload,_ for local development. When using docker-compose up, it will override the entrypoint defined in the Dockerfile.

Fix #182 