### PR TITLE
Allow meta_entrega greater than 100 when percent mode

### DIFF
--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -174,7 +174,7 @@ Trabalho.
 * O campo `meta_entrega` tem que ser um inteiro maior ou igual a zero.
 * Para o campo `tipo_meta` são permitidos os seguintes valores:
   * `unidade`
-  * `percentual` (nesse caso, `meta_entrega` tem que estar entre `0` e `100`)
+  * `percentual`
 
 
 ### 3. Planos de Trabalho

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -423,21 +423,6 @@ class EntregaSchema(BaseModel):
         max_length=STR_FIELD_MAX_SIZE,
     )
 
-    @model_validator(mode="after")
-    def validate_meta_percentual(self) -> "EntregaSchema":
-        if (
-            self.meta_entrega is not None
-            and isinstance(self.meta_entrega, int)
-            and self.tipo_meta == TipoMeta.percentual.value
-            and not 0 <= self.meta_entrega <= 100
-        ):
-            raise ValueError(
-                "Valor meta_entrega deve estar entre 0 e 100 "
-                "quando tipo_entrega for percentual."
-            )
-        return self
-
-
 class PlanoEntregasSchema(BaseModel):
     __doc__ = PlanoEntregas.__doc__
     model_config = ConfigDict(from_attributes=True)

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -464,7 +464,7 @@ class TestCreatePEInputValidation(BasePETest):
         "id_plano_entregas, meta_entrega, tipo_meta",
         [
             ("555", 10, "unidade"),
-            ("556", 100, "percentual"),
+            ("556", -10, "percentual"),
             ("557", 1, "percentual"),
             ("558", -10, "unidade"),
             ("559", 200, "percentual"),
@@ -478,7 +478,7 @@ class TestCreatePEInputValidation(BasePETest):
         meta_entrega: int,
         tipo_meta: str,
     ):
-        """Tenta criar um Plano de Entregas com entrega com percentuais inválidos"""
+        """Tenta criar um Plano de Entregas com meta_entrega com valores inválidos"""
 
         input_pe = deepcopy(self.input_pe)
         input_pe["id_plano_entregas"] = id_plano_entregas
@@ -487,17 +487,7 @@ class TestCreatePEInputValidation(BasePETest):
 
         response = self.put_plano_entregas(input_pe)
 
-        if tipo_meta == "percentual" and (meta_entrega < 0 or meta_entrega > 100):
-            assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
-            detail_message = (
-                "Valor meta_entrega deve estar entre 0 e 100 "
-                "quando tipo_entrega for percentual."
-            )
-            assert any(
-                f"Value error, {detail_message}" in error["msg"]
-                for error in response.json().get("detail")
-            )
-        elif tipo_meta == "unidade" and (meta_entrega < 0):
+        if meta_entrega < 0:
             assert response.status_code == http_status.HTTP_422_UNPROCESSABLE_ENTITY
             detail_message = "Input should be greater than or equal to 0"
             assert any(


### PR DESCRIPTION
Fix #198 

Allow the meta_entrega value to exceed 100 when in percent mode.

- Remove the rule from the documentation.
- Remove the validation from Pydantic.
- Adjust the Plano Entrega tests for meta_entrega.