### PR TITLE
Create validation for empty Entregas list

### DIFF
--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -176,6 +176,8 @@ Trabalho.
   * `unidade`
   * `percentual`
 
+**Atenção:** não é permitido o envio do Plano de Entregas sem entregas, exceto
+se o status do Plano de Entrega for igual a 1 (Cancelado).
 
 ### 3. Planos de Trabalho
 


### PR DESCRIPTION
Fix #200 

- Include a warning in the documentation.
- Create a Pydantic validation to reject empty "Entregas" when submitting "Plano de Entregas", except when the status equals 1.
- Update the test_create_plano_entregas_sem_entregas test.