### PR TITLE
Create validation for empty Contribuicoes list

### DIFF
--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -191,7 +191,14 @@ Os **Planos de Trabalho** submetidos devem seguir as seguintes regras:
 * O `cpf_participante` deve se referir a um participante já cadastrado
   pelo endpoint **Participante**.
 * O valor de `carga_horaria_disponivel` deve ser maior ou igual a zero.
+* Para o campo `status` são permitidos os seguintes valores:
+  * `1`: Cancelado;
+  * `2`: Aprovado;
+  * `3`: Em execução;
+  * `4`: Concluído;
 
+**Atenção:** não é permitido o envio do Plano de Trabalho sem contribuições, exceto
+se o status do Plano de Trabalho for igual a 1 (Cancelado).
 
 #### 3.1. Contribuição
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -107,6 +107,14 @@ class StatusPlanoEntregasEnum(IntEnum):
     concluido = 4
     avaliado = 5
 
+class StatusPlanoTrabalhoEnum(IntEnum):
+    """Status do Plano de Trabalho"""
+
+    cancelado = 1
+    aprovado = 2
+    em_execucao = 3
+    concluido = 4
+
 
 # Classes de esquemas Pydantic
 
@@ -267,7 +275,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Identificador único do plano de trabalho",
         description=PlanoTrabalho.id_plano_trabalho.comment,
     )
-    status: Annotated[PositiveInt, Field(le=4)] = Field(
+    status: StatusPlanoTrabalhoEnum = Field(
         title="Status do plano de trabalho",
         description=PlanoTrabalho.status.comment,
     )

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -313,8 +313,7 @@ class PlanoTrabalhoSchema(BaseModel):
         title="Carga horária disponível do participante",
         description=PlanoTrabalho.carga_horaria_disponivel.comment,
     )
-
-    contribuicoes: Optional[List[ContribuicaoSchema]] = Field(
+    contribuicoes: List[ContribuicaoSchema] = Field(
         default_factory=list,
         title="Contribuições",
         description="Lista de Contribuições planejadas para o Plano de Trabalho.",
@@ -400,6 +399,14 @@ class PlanoTrabalhoSchema(BaseModel):
                     )
         return avaliacoes
 
+    @model_validator(mode="after")
+    def validate_contribuicoes_not_empty(self) -> "PlanoTrabalhoSchema":
+        """Valida se a lista de contribuicoes não está vazia, exceto se
+        o status for igual a 1 - Cancelado
+        """
+        if not self.contribuicoes and self.status != StatusPlanoTrabalhoEnum.cancelado:
+            raise ValueError("A lista de contribuições não pode estar vazia")
+        return self
 
 class EntregaSchema(BaseModel):
     __doc__ = Entrega.__doc__

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -481,6 +481,40 @@ class TestCreatePlanoTrabalho(BasePTTest):
         else:
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
+    @pytest.mark.parametrize(
+        ("contribuicoes", "status_pt"),
+        [
+            ([], 2),
+            ([], 4),
+            (None, 1),
+        ]
+    )
+    def test_create_plano_trabalho_sem_contribuicoes(
+        self,
+        contribuicoes,
+        status_pt
+    ):
+        """Tenta criar um plano de trabalho que não contém contribuições.
+        Caso o status for 1 - Cancelado, o status deve ser 201 Created.
+        """
+        input_pt = deepcopy(self.input_pt)
+        input_pt["contribuicoes"] = contribuicoes
+        input_pt["status"] = status_pt
+
+        response = self.put_plano_trabalho(input_pt)
+
+        if isinstance(contribuicoes, list):
+            if status_pt != 1 and not contribuicoes:
+                assert response.status_code == 422
+                detail_message = (
+                    "A lista de contribuições não pode estar vazia"
+                )
+                assert_error_message(response, detail_message)
+            else:
+                assert response.status_code == status.HTTP_201_CREATED
+        else:
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
 
 class TestUpdatePlanoDeTrabalho(BasePTTest):
     """Testes para atualizar um Plano de Trabalho existente.

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -20,7 +20,6 @@ from ..conftest import MAX_INT, MAX_BIGINT
 FIELDS_PLANO_TRABALHO = {
     "optional": (
         ["avaliacoes_registros_execucao"],
-        ["contribuicoes"],
     ),
     "mandatory": (
         ["origem_unidade"],
@@ -34,6 +33,7 @@ FIELDS_PLANO_TRABALHO = {
         ["data_inicio"],
         ["data_termino"],
         ["carga_horaria_disponivel"],
+        ["contribuicoes"],
     ),
 }
 

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -420,15 +420,8 @@ class TestCreatePlanoTrabalho(BasePTTest):
             assert response.status_code == status.HTTP_201_CREATED
         else:
             assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
-            detail_messages = [
-                "Input should be greater than 0",
-                "Input should be less than or equal to 4",
-            ]
-            assert any(
-                detail_message == error["msg"]
-                for error in response.json().get("detail", {})
-                for detail_message in detail_messages
-            )
+            detail_msg = "Input should be 1, 2, 3 or 4"
+            assert_error_message(response, detail_msg)
 
     @pytest.mark.parametrize(
         (


### PR DESCRIPTION
Fix #205 

- Added a warning in the documentation regarding Contribuições.
- Implemented Pydantic validation to reject empty Contribuições when submitting a Plano de Trabalho, except when status == 1.
- Created a new test: _test_create_plano_trabalho_sem_contribuicoes_.
- Updated schema to use an Enum annotation for the Status field.