### PR TITLE
Implement length validation for cod_unidade_autorizadora based on origem_unidade

### DIFF
--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -117,6 +117,11 @@ responsável pelo envio dos dados.
 Exemplo: "Ministério da Gestão e da Inovação em Serviços Públicos" ou
 "Conselho de Controle de Atividades Financeiras"
 
+Caso seja um unidade de nível maior que Lv1, deve-se informar o código
+de 14 dígitos - Código do órgão e código da Unidade Organizacional (Uorg)
+no sistema Siape. Os cinco primeiros dígitos correspondem ao Órgão e os
+nove últimos correspondem a Uorg.
+
 Obs: A instituição que não esteja no SIAPE pode usar o código SIORG.
 Nesse caso, utilizar o valor "SIORG" no campo `origem_unidade`.
 

--- a/src/models.py
+++ b/src/models.py
@@ -48,7 +48,11 @@ class PlanoEntregas(Base):
         "imediatamente inferiores, ou seja, para Uorg Lv2 e Uorg "
         "Lv3. Haverá situações, portanto, em que uma unidade do "
         "Uorg Lv1 de nível 2 ou 3 poderá enviar dados diretamente "
-        "para API.",
+        "para API. Caso seja um unidade de nível maior que Lv1, deve-se "
+        "informar o código de 14 dígitos - Código do órgão e código da "
+        "Unidade Organizacional (Uorg) no sistema Siape. Os cinco "
+        "primeiros dígitos correspondem ao Órgão e os nove últimos "
+        "correspondem a Uorg."
     )
     cod_unidade_instituidora = Column(
         BigInteger,
@@ -113,7 +117,7 @@ class PlanoEntregas(Base):
             superior ao da chefia da unidade de execução, em até
             trinta dias após o término do plano de entregas, em uma
             das seguintes escalas:
-            
+
             I - excepcional: plano de entregas executado com desempenho
             muito acima do esperado;
             II - alto desempenho: plano de entregas executado com
@@ -268,7 +272,7 @@ class PlanoTrabalho(Base):
         primary_key=True,
         nullable=False,
         comment="Código da unidade organizacional (UORG) no Sistema "
-        "Integrado de Administração de Recursos Humanos (Siape) "
+        "Integrado de Administração de Recursos Humanos (SIAPE) "
         "corresponde à Unidade de autorização. Referente ao artigo "
         "3º do Decreto nº 11.072, de 17 de maio de 2022. De forma "
         "geral, são os “Ministros de Estado, os dirigentes máximos "
@@ -280,7 +284,11 @@ class PlanoTrabalho(Base):
         "imediatamente inferiores, ou seja, para Uorg Lv2 e Uorg "
         "Lv3. Haverá situações, portanto, em que uma unidade do "
         "Uorg Lv1 de nível 2 ou 3 poderá enviar dados diretamente "
-        "para API.",
+        "para API. Caso seja um unidade de nível maior que Lv1, deve-se "
+        "informar o código de 14 dígitos - Código do órgão e código da "
+        "Unidade Organizacional (Uorg) no sistema Siape. Os cinco "
+        "primeiros dígitos correspondem ao Órgão e os nove últimos "
+        "correspondem a Uorg."
     )
     id_plano_trabalho = Column(
         String,
@@ -621,6 +629,11 @@ class Participante(Base):
         "autorização, é hoje a UORG responsável pelo envio dos dados.\n\n"
         'Exemplo: "Ministério da Gestão e da Inovação em Serviços Públicos" '
         'ou "Conselho de Controle de Atividades Financeiras"\n\n'
+        "Caso seja um unidade de nível maior que Lv1, deve-se "
+        "informar o código de 14 dígitos - Código do órgão e código da "
+        "Unidade Organizacional (Uorg) no sistema Siape. Os cinco "
+        "primeiros dígitos correspondem ao Órgão e os nove últimos "
+        "correspondem a Uorg.\n\n"
         "Obs: A instituição que não esteja no SIAPE pode usar o código SIORG.",
     )
     cod_unidade_lotacao = Column(

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -103,6 +103,7 @@ class BaseParticipanteTest:
     def put_participante(
         self,
         input_part: dict,
+        origem_unidade: Optional[str] = None,
         cod_unidade_autorizadora: Optional[int] = None,
         cod_unidade_lotacao: Optional[int] = None,
         matricula_siape: Optional[str] = None,
@@ -120,6 +121,8 @@ class BaseParticipanteTest:
         Returns:
             httpx.Response: A resposta da API.
         """
+        if origem_unidade is None:
+            origem_unidade = input_part["origem_unidade"]
         if cod_unidade_autorizadora is None:
             cod_unidade_autorizadora = input_part["cod_unidade_autorizadora"]
         if cod_unidade_lotacao is None:
@@ -131,7 +134,7 @@ class BaseParticipanteTest:
 
         response = self.client.put(
             (
-                f"/organizacao/SIAPE/{cod_unidade_autorizadora}"
+                f"/organizacao/{origem_unidade}/{cod_unidade_autorizadora}"
                 f"/{cod_unidade_lotacao}/participante/{matricula_siape}"
             ),
             json=input_part,
@@ -521,6 +524,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
     def test_create_participante_missing_mandatory_fields(self, missing_fields: list):
         """Tenta submeter participantes faltando campos obrigatórios"""
         input_part = deepcopy(self.input_part)
+        origem_unidade = input_part["origem_unidade"]
         cod_unidade_lotacao = input_part["cod_unidade_lotacao"]
         matricula_siape = input_part["matricula_siape"]
         offset, field_list = missing_fields
@@ -532,6 +536,7 @@ class TestCreateParticipanteFieldValidation(BaseParticipanteTest):
         )
         response = self.put_participante(
             input_part,
+            origem_unidade=origem_unidade,
             cod_unidade_autorizadora=self.user1_credentials["cod_unidade_autorizadora"],
             cod_unidade_lotacao=cod_unidade_lotacao,
             matricula_siape=matricula_siape,

--- a/tests/participantes_test.py
+++ b/tests/participantes_test.py
@@ -239,7 +239,6 @@ class TestCreateParticipante(BaseParticipanteTest):
             (MAX_BIGINT + 1, 1, 99),  # cod_unidade_autorizadora maior que MAX_BIGINT
             (1, MAX_BIGINT + 1, 99),  # cod_unidade_instituidora maior que MAX_BIGINT
             (1, 1, MAX_BIGINT + 1),  # cod_unidade_lotacao maior que MAX_BIGINT
-            (MAX_BIGINT, 1, 99),  # cod_unidade_autorizadora igual a MAX_BIGINT
             (1, MAX_BIGINT, 99),  # cod_unidade_instituidora igual a MAX_BIGINT
             (1, 1, MAX_BIGINT),  # cod_unidade_lotacao igual a MAX_BIGINT
         ],

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -644,7 +644,6 @@ class TestCreatePEInputValidation(BasePETest):
             (-1, 99, 99),  # cod_unidade_autorizadora negativo
             (1, -1, 99),  # cod_unidade_instituidora negativo
             (1, 99, -1),  # cod_unidade_executora negativo
-            (MAX_BIGINT, 99, 99),  # cod_unidade_autorizadora igual a MAX_BIGINT
             (1, MAX_BIGINT, 99),  # cod_unidade_instituidora igual a MAX_BIGINT
             (1, 99, MAX_BIGINT),  # cod_unidade_executora igual a MAX_BIGINT
             (MAX_BIGINT + 1, 99, 99),  # cod_unidade_autorizadora maior que MAX_BIGINT

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -433,16 +433,9 @@ class TestCreatePlanoTrabalho(BasePTTest):
             (1, -1, 99, 80),  # cod_unidade_executora negativo
             (1, 99, -1, 80),  # cod_unidade_lotacao_participante negativo
             (1, 99, 99, -80),  # carga_horaria_disponivel negativo
-            (
-                MAX_BIGINT + 1,
-                1,
-                99,
-                80,
-            ),  # cod_unidade_autorizadora maior que MAX_BIGINT
             (1, MAX_BIGINT + 1, 99, 80),  # cod_unidade_executora maior que MAX_BIGINT
             (1, 99, MAX_BIGINT + 1, 80),  # cod_unidade_lotacao maior que MAX_BIGINT
             (1, 99, 99, MAX_INT + 1),  # carga_horaria_disponivel maior que MAX_INT
-            (MAX_BIGINT, 1, 99, 80),  # cod_unidade_autorizadora igual a MAX_BIGINT
             (1, MAX_BIGINT, 99, 80),  # cod_unidade_executora igual a MAX_BIGINT
             (1, 99, MAX_BIGINT, 80),  # cod_unidade_lotacao igual a MAX_BIGINT
             (1, 99, 99, MAX_INT),  # carga_horaria_disponivel igual a MAX_INT

--- a/tests/user_test.py
+++ b/tests/user_test.py
@@ -274,7 +274,9 @@ class TestGetSingleUser(BaseUserTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
     def test_get_user_logged_in_not_admin(
-        self, user1_credentials: dict, header_usr_2: dict  # user is_admin=False
+        self,
+        user1_credentials: dict,
+        header_usr_2: dict,  # user is_admin=False
     ):
         """Testa a obtenção de dados de um outro usuário por um usuário logado,
         mas não admin.
@@ -287,7 +289,9 @@ class TestGetSingleUser(BaseUserTest):
         assert response.status_code == status.HTTP_403_FORBIDDEN
 
     def test_get_user_self_logged_in_not_admin(
-        self, user2_credentials: dict, header_usr_2: dict  # user is_admin=False
+        self,
+        user2_credentials: dict,
+        header_usr_2: dict,  # user is_admin=False
     ):
         """Testa a obtenção de dados do próprio usuário logado, mas não admin.
 
@@ -299,7 +303,9 @@ class TestGetSingleUser(BaseUserTest):
         assert response.status_code == status.HTTP_200_OK
 
     def test_get_user_as_admin(
-        self, user1_credentials: dict, header_usr_1: dict  # user is_admin=True
+        self,
+        user1_credentials: dict,
+        header_usr_1: dict,  # user is_admin=True
     ):
         """Testa a obtenção de um usuário por um usuário admin.
 


### PR DESCRIPTION
Fix #204 
- Implement length validation for _cod_unidade_autorizadora_ based on origem_unidade (SIAPE or SIORG).
- Create tests for invalid cod_unidade_autorizadora values in **Participantes**, **Plano de Entregas** and **Users**
- Add pydantic validation rule in _schemas_
- Update existing tests based on this new validation rule.