### PR TITLE
Restrict future date for data_avaliacao_registros_execucao

### DIFF
--- a/src/docs/description.md
+++ b/src/docs/description.md
@@ -234,6 +234,8 @@ se o status do Plano de Trabalho for igual a 1 (Cancelado).
   entre diferentes Avaliações de Registro de Execução para um mesmo
   Plano de Trabalho.
 * O campo `avaliacao_registros_execucao` admite valores de `1` a `5`.
+* A `data_avaliacao_registros_execucao` não pode ser superior à data
+  de envio.
 
 
 -------

--- a/src/models.py
+++ b/src/models.py
@@ -562,7 +562,8 @@ class AvaliacaoRegistrosExecucao(Base):
         nullable=False,
         comment="Data em que foi realizada avaliação dos registros de execução do "
         "plano de trabalho no período avaliativo. Regras de validação: deve ser "
-        "igual ou posterior à “data_inicio_periodo_avaliativo”",
+        "igual ou posterior à “data_inicio_periodo_avaliativo e não pode ser uma"
+        "data futura”",
     )
     data_atualizacao = Column(DateTime)
     data_insercao = Column(DateTime, nullable=False)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -245,6 +245,18 @@ class AvaliacaoRegistrosExecucaoSchema(BaseModel):
             )
         return value
 
+    @field_validator("data_avaliacao_registros_execucao")
+    @staticmethod
+    def validate_data_avaliacao_not_future(data_avaliacao_registros_execucao: date) -> date:
+        """Valida se a data de avaliação é inferior ou igual a data de envio."""
+        print (data_avaliacao_registros_execucao)
+        if data_avaliacao_registros_execucao > date.today():
+            raise ValueError(
+                "A data de avaliação de registros de execução não pode ser "
+                "superior à data atual."
+            )
+        return data_avaliacao_registros_execucao
+
     @model_validator(mode="after")
     def validate_data_fim_periodo_avaliativo(
         self,

--- a/tests/plano_trabalho/date_validation_test.py
+++ b/tests/plano_trabalho/date_validation_test.py
@@ -275,9 +275,9 @@ class TestCreatePTDataAvaliacao(BasePTTest):
         input_pt["avaliacoes_registros_execucao"][0][
             "data_inicio_periodo_avaliativo"
         ] = data_inicio_periodo_avaliativo
-        input_pt["avaliacoes_registros_execucao"][0][
-            "data_fim_periodo_avaliativo"
-        ] = data_fim_periodo_avaliativo
+        input_pt["avaliacoes_registros_execucao"][0]["data_fim_periodo_avaliativo"] = (
+            data_fim_periodo_avaliativo
+        )
 
         response = self.put_plano_trabalho(input_pt)
 
@@ -297,6 +297,37 @@ class TestCreatePTDataAvaliacao(BasePTTest):
             detail_message = (
                 "A data de início do período avaliativo deve ser igual ou "
                 "posterior à data de início do Plano de Trabalho."
+            )
+            assert_error_message(response, detail_message)
+        else:
+            assert response.status_code == status.HTTP_201_CREATED
+
+    @pytest.mark.parametrize(
+        "data_avaliacao_registros_execucao",
+        [
+            "2099-01-01",  # data futura
+            date.today().strftime("%Y-%m-%d"),  # data atual
+            "2023-06-02",  # data passada
+        ],
+    )
+    def test_create_pt_data_avaliacao_future_date(
+        self,
+        data_avaliacao_registros_execucao: str,
+    ):
+        """Verifica se a data de avaliação do registro de execução é
+        inferior ou igual a data de envio.
+        """
+        input_pt = deepcopy(self.input_pt)
+        input_pt["avaliacoes_registros_execucao"][0][
+            "data_avaliacao_registros_execucao"
+        ] = data_avaliacao_registros_execucao
+        print (input_pt)
+        response = self.put_plano_trabalho(input_pt)
+        if date.fromisoformat(data_avaliacao_registros_execucao) > date.today():
+            assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+            detail_message = (
+                "A data de avaliação de registros de execução não pode ser "
+                "superior à data atual."
             )
             assert_error_message(response, detail_message)
         else:


### PR DESCRIPTION
Fix #208

- Add validation rule for future dates in schemas.py (cannot be greater than the send date)
- Create tests
- Update documentation