### PR TITLE
Split schemas for PlanoTrabalho and PlanoEntregas

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -476,7 +476,7 @@ async def reset_password(
     "/plano_entregas/{id_plano_entregas}",
     summary="Consulta plano de entregas",
     tags=["plano de entregas"],
-    response_model=schemas.PlanoEntregasSchema,
+    response_model=schemas.PlanoEntregasResponseSchema,
     responses={
         **response_schemas.outra_unidade_error,
         404: response_schemas.NotFoundErrorResponse.docs(
@@ -607,7 +607,7 @@ async def create_or_update_plano_entregas(
     "/plano_trabalho/{id_plano_trabalho}",
     summary="Consulta plano de trabalho",
     tags=["plano de trabalho"],
-    response_model=schemas.PlanoTrabalhoSchema,
+    response_model=schemas.PlanoTrabalhoResponseSchema,
     responses={
         **response_schemas.outra_unidade_error,
         404: response_schemas.NotFoundErrorResponse.docs(

--- a/src/crud.py
+++ b/src/crud.py
@@ -18,7 +18,7 @@ async def get_plano_trabalho(
     origem_unidade: str,
     cod_unidade_autorizadora: int,
     id_plano_trabalho: str,
-) -> Optional[schemas.PlanoTrabalhoSchema]:
+) -> Optional[schemas.PlanoTrabalhoResponseSchema]:
     """Traz um plano de trabalho a partir do banco de dados, consultando
     a partir dos parâmetros informados.
 
@@ -41,7 +41,7 @@ async def get_plano_trabalho(
         )
         db_plano_trabalho = result.unique().scalar_one_or_none()
     if db_plano_trabalho:
-        return schemas.PlanoTrabalhoSchema.model_validate(db_plano_trabalho)
+         return schemas.PlanoTrabalhoResponseSchema.model_validate(db_plano_trabalho)
     return None
 
 
@@ -254,7 +254,7 @@ async def get_plano_entregas(
     origem_unidade: str,
     cod_unidade_autorizadora: int,
     id_plano_entregas: int,
-) -> Optional[schemas.PlanoEntregasSchema]:
+) -> Optional[schemas.PlanoEntregasResponseSchema]:
     """Traz um plano de entregas a partir do banco de dados, consultando
     a partir dos parâmetros informados.
 
@@ -278,7 +278,7 @@ async def get_plano_entregas(
         )
         db_plano_entrega = result.unique().scalar_one_or_none()
     if db_plano_entrega:
-        return db_plano_entrega
+        return schemas.PlanoEntregasResponseSchema.model_validate(db_plano_entrega)
     return None
 
 

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -456,7 +456,6 @@ class PlanoTrabalhoSchema(PlanoTrabalhoBase):
             raise ValueError("A lista de contribuições não pode estar vazia")
         return self
 
-
 class EntregaSchema(BaseModel):
     __doc__ = Entrega.__doc__
     model_config = ConfigDict(from_attributes=True)
@@ -498,7 +497,7 @@ class EntregaSchema(BaseModel):
     )
 
 
-class PlanoEntregasSchema(BaseModel):
+class PlanoEntregasBase(BaseModel):
     __doc__ = PlanoEntregas.__doc__
     model_config = ConfigDict(from_attributes=True)
     origem_unidade: OrigemUnidadeEnum = Field(
@@ -547,6 +546,12 @@ class PlanoEntregasSchema(BaseModel):
         description="Lista de entregas associadas ao Plano de Entregas",
     )
 
+# Utilizado para requisições GET (sem validação)"""
+class PlanoEntregasResponseSchema(PlanoEntregasBase):
+    pass
+
+# Utilizado para requisições POST/PUT (com validação)
+class PlanoEntregasSchema(PlanoEntregasBase):
     @model_validator(mode="after")
     def validate_entregas_not_empty(self) -> "PlanoEntregasSchema":
         """Valida se a lista de entregas não está vazia, exceto se
@@ -594,8 +599,6 @@ class PlanoEntregasSchema(BaseModel):
             self.origem_unidade, self.cod_unidade_autorizadora
         )
         return self
-
-
 class ParticipanteSchema(BaseModel):
     __doc__ = Participante.__doc__
     model_config = ConfigDict(from_attributes=True)

--- a/src/schemas.py
+++ b/src/schemas.py
@@ -282,8 +282,7 @@ class AvaliacaoRegistrosExecucaoSchema(BaseModel):
             )
         return self
 
-
-class PlanoTrabalhoSchema(BaseModel):
+class PlanoTrabalhoBase(BaseModel):
     __doc__ = PlanoTrabalho.__doc__
     model_config = ConfigDict(from_attributes=True)
 
@@ -349,6 +348,13 @@ class PlanoTrabalhoSchema(BaseModel):
             description="Lista de avaliações de registros de execução do Plano de Trabalho.",
         )
     )
+
+# Utilizado para requisições GET (sem validação)"""
+class PlanoTrabalhoResponseSchema(PlanoTrabalhoBase):
+    pass
+
+# Utilizado para requisições POST/PUT (com validação)
+class PlanoTrabalhoSchema(PlanoTrabalhoBase):
 
     @field_validator("cpf_participante")
     @staticmethod


### PR DESCRIPTION
Fix #213 
Split PlanoTrabalhoSchema and PlanoEntregasSchema in two separate chemas each:
- One with strict validation for create/update 
- One more relaxed for GET responses

This separation prevents server-side validation errors when returning legacy or incomplete data from the database, while maintaining strict validation for incoming data.