### PR TITLE
Add transactional support in update_plano_trabalho and update_plano_entregas

### DIFF
--- a/src/crud.py
+++ b/src/crud.py
@@ -555,7 +555,7 @@ async def update_participante(
             com o retorno de create_participante.
     """
     async with db_session as session:
-        # find and delete
+        # find and replace
         result = await session.execute(
             select(models.Participante)
             .filter_by(origem_unidade=participante.origem_unidade)


### PR DESCRIPTION
fix #215 
- Implement transaction mode using session.begin() in update_plano_trabalho and update_plano_entregas to ensure data consistency.
- Create helper function _build_model_plano to encapsulate shared logic between create and update operations, improving code reusability.