### PR TITLE
Implementa upsert para planos de entregas e trabalho

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -29,7 +29,7 @@ from db_config import (
 import email_config
 import response_schemas
 import schemas
-from util import check_permissions, over_a_year
+from util import check_permissions
 
 DEFAULT_TOKEN_EXPIRE_MINS = 30
 ACCESS_TOKEN_EXPIRE_MINUTES = int(
@@ -580,38 +580,14 @@ async def create_or_update_plano_entregas(
         )
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
 
-    # Verifica se já existe
-    db_plano_entregas = await crud.get_plano_entregas(
-        db_session=db,
-        origem_unidade=origem_unidade,
-        cod_unidade_autorizadora=cod_unidade_autorizadora,
-        id_plano_entregas=id_plano_entregas,
-    )
-
     try:
-        if not db_plano_entregas:  # create
-            if over_a_year(plano_entregas.data_inicio, plano_entregas.data_termino) == 1:
-                    detail_msg = (
-                        "Plano de entregas não pode abranger período maior que 1 ano"
-                    )
-                    raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
-
-            novo_plano_entregas = await crud.create_plano_entregas(
-                db_session=db,
-                plano_entregas=novo_plano_entregas,
-            )
+        novo_plano_entregas, created = await crud.upsert_plano_entregas(
+            db_session=db,
+            plano_entregas=novo_plano_entregas,
+            update_year_validation_cutoff_date=PT_PE_UPDATE_YEAR_VALIDATION_CUTOFF_DATE,
+        )
+        if created:
             response.status_code = status.HTTP_201_CREATED
-        else:  # update
-            if over_a_year(plano_entregas.data_inicio, plano_entregas.data_termino) == 1 and \
-                plano_entregas.data_inicio > PT_PE_UPDATE_YEAR_VALIDATION_CUTOFF_DATE:
-                    detail_msg = (
-                        "Plano de entregas não pode abranger período maior que 1 ano"
-                    )
-                    raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
-            novo_plano_entregas = await crud.update_plano_entregas(
-                db_session=db,
-                plano_entregas=novo_plano_entregas,
-            )
         return novo_plano_entregas
     except IntegrityError as exception:
         raise HTTPException(
@@ -725,39 +701,17 @@ async def create_or_update_plano_trabalho(
         )
         raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
 
-    # Verifica se já existe
-    db_plano_trabalho = await crud.get_plano_trabalho(
-        db_session=db,
-        origem_unidade=origem_unidade,
-        cod_unidade_autorizadora=cod_unidade_autorizadora,
-        id_plano_trabalho=id_plano_trabalho,
-    )
-
     try:
-        if not db_plano_trabalho:  # create
-            if over_a_year(plano_trabalho.data_inicio, plano_trabalho.data_termino) == 1:
-                detail_msg = (
-                    "Plano de trabalho não pode abranger período maior que 1 ano"
-                )
-                raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
-
-            novo_plano_trabalho = await crud.create_plano_trabalho(
-                db_session=db,
-                plano_trabalho=novo_plano_trabalho,
-            )
+        novo_plano_trabalho, created = await crud.upsert_plano_trabalho(
+            db_session=db,
+            plano_trabalho=novo_plano_trabalho,
+            update_year_validation_cutoff_date=(
+                PT_PE_UPDATE_YEAR_VALIDATION_CUTOFF_DATE
+            ),
+        )
+        if created:
             response.status_code = status.HTTP_201_CREATED
-        else:  # update
-            if over_a_year(plano_trabalho.data_inicio, plano_trabalho.data_termino) == 1 and \
-                plano_trabalho.data_inicio > PT_PE_UPDATE_YEAR_VALIDATION_CUTOFF_DATE:
-                detail_msg = (
-                    "Plano de trabalho não pode abranger período maior que 1 ano"
-                )
-                raise HTTPException(status.HTTP_422_UNPROCESSABLE_ENTITY, detail=detail_msg)
-
-            novo_plano_trabalho = await crud.update_plano_trabalho(
-                db_session=db,
-                plano_trabalho=novo_plano_trabalho,
-            )
+        else:
             response.status_code = status.HTTP_200_OK
     except IntegrityError as exception:
         raise HTTPException(

--- a/src/crud.py
+++ b/src/crud.py
@@ -565,61 +565,127 @@ def _build_plano_entregas_model(
     return db_plano_entregas
 
 
-async def create_plano_entregas(
+# async def create_plano_entregas(
+#     db_session: DbContextManager,
+#     plano_entregas: schemas.PlanoEntregasSchema,
+# ) -> schemas.PlanoEntregasSchema:
+#     """Cria um plano de trabalho definido pelos dados do schema Pydantic
+#     plano_entregas.
+
+#     Args:
+#         db_session (DbContextManager): Context manager para a sessão
+#             async do SQL Alchemy.
+#         plano_entregas (schemas.PlanoEntregasSchema): Dados do plano
+#             de entregas como um esquema Pydantic.
+
+#     Returns:
+#         schemas.PlanoEntregasSchema: Esquema Pydantic do Plano de Entregas
+#             com os dados que foram gravados no banco.
+#     """
+#     creation_timestamp = datetime.now()
+#     db_plano_entregas = _build_plano_entregas_model(plano_entregas, creation_timestamp)
+#     async with db_session as session:
+#         for entrega in db_plano_entregas.entregas:
+#             session.add(entrega)
+#         session.add(db_plano_entregas)
+#         await session.commit()
+#         await session.refresh(db_plano_entregas)
+#     return schemas.PlanoEntregasSchema.model_validate(db_plano_entregas)
+
+
+async def upsert_plano_entregas(
     db_session: DbContextManager,
     plano_entregas: schemas.PlanoEntregasSchema,
-) -> schemas.PlanoEntregasSchema:
-    """Cria um plano de trabalho definido pelos dados do schema Pydantic
-    plano_entregas.
-
-    Args:
-        db_session (DbContextManager): Context manager para a sessão
-            async do SQL Alchemy.
-        plano_entregas (schemas.PlanoEntregasSchema): Dados do plano
-            de entregas como um esquema Pydantic.
-
-    Returns:
-        schemas.PlanoEntregasSchema: Esquema Pydantic do Plano de Entregas
-            com os dados que foram gravados no banco.
-    """
-    creation_timestamp = datetime.now()
-    db_plano_entregas = _build_plano_entregas_model(plano_entregas, creation_timestamp)
-    async with db_session as session:
-        for entrega in db_plano_entregas.entregas:
-            session.add(entrega)
-        session.add(db_plano_entregas)
-        await session.commit()
-        await session.refresh(db_plano_entregas)
-    return schemas.PlanoEntregasSchema.model_validate(db_plano_entregas)
-
-
-async def update_plano_entregas(
-    db_session: DbContextManager,
-    plano_entregas: schemas.PlanoEntregasSchema,
-) -> schemas.PlanoEntregasSchema:
-    """Atualiza um plano de entregas conforme os dados recebidos no
+    update_year_validation_cutoff_date: date,
+) -> tuple[schemas.PlanoEntregasSchema, bool]:
+    """Cria ou atualiza um plano de entregas conforme os dados recebidos no
     esquema Pydantic em plano_entregas.
 
-    Os dados existentes são primeiro apagados do banco para depois
-    inserir os dados recebidos.
+    O registro do plano é gravado com upsert para evitar conflitos de
+    integridade em transações concorrentes. As entregas existentes são
+    apagadas e recriadas dentro da mesma transação.
 
     Args:
         db_session (DbContextManager): Context manager para a sessão
             async do SQL Alchemy.
         plano_entregas (schemas.PlanoEntregasSchema): Dados do plano
             de entregas como um esquema Pydantic.
+        update_year_validation_cutoff_date (date): Data de corte para aplicar
+            a validação de período maior que 1 ano também nas atualizações.
 
     Returns:
-        schemas.PlanoEntregasSchema: Esquema Pydantic do Plano de Entregas
-            com o retorno de create_plano_entregas.
+        tuple[schemas.PlanoEntregasSchema, bool]: Esquema Pydantic do Plano
+            de Entregas e booleano indicando se foi criado.
     """
-    creation_timestamp = datetime.now()
-    db_plano_entregas_atualizado = _build_plano_entregas_model(
-        plano_entregas, creation_timestamp
-    )
+    timestamp = datetime.now()
+    plano_values = plano_entregas.model_dump(exclude={"entregas"})
+    plano_values["data_insercao"] = timestamp
+    entrega_identity = {
+        "origem_unidade": plano_entregas.origem_unidade,
+        "cod_unidade_autorizadora": plano_entregas.cod_unidade_autorizadora,
+        "id_plano_entregas": plano_entregas.id_plano_entregas,
+    }
+    entregas_values = [
+        {
+            **entrega.model_dump(),
+            **entrega_identity,
+            "data_insercao": timestamp,
+        }
+        for entrega in plano_entregas.entregas
+    ]
 
     async with db_session as session:
         async with session.begin():
+            result = await session.execute(
+                select(models.PlanoEntregas.id)
+                .filter_by(origem_unidade=plano_entregas.origem_unidade)
+                .filter_by(
+                    cod_unidade_autorizadora=plano_entregas.cod_unidade_autorizadora
+                )
+                .filter_by(id_plano_entregas=plano_entregas.id_plano_entregas)
+            )
+            plano_exists = result.scalar_one_or_none() is not None
+            created = not plano_exists
+            if over_a_year(plano_entregas.data_inicio, plano_entregas.data_termino) == 1:
+                if (
+                    not plano_exists
+                    or plano_entregas.data_inicio > update_year_validation_cutoff_date
+                ):
+                    raise HTTPException(
+                        status_code=422,
+                        detail="Plano de entregas não pode abranger período maior que 1 ano",
+                    )
+
+            insert_stmt = insert(models.PlanoEntregas).values(**plano_values)
+            update_values = {
+                column.name: insert_stmt.excluded[column.name]
+                for column in models.PlanoEntregas.__table__.columns
+                if column.name not in ("id", "data_insercao", "data_atualizacao")
+            }
+            update_values["data_atualizacao"] = timestamp
+            await session.execute(
+                insert_stmt.on_conflict_do_update(
+                    index_elements=[
+                        "origem_unidade",
+                        "cod_unidade_autorizadora",
+                        "id_plano_entregas",
+                    ],
+                    set_=update_values,
+                )
+            )
+
+            await session.execute(
+                models.Entrega.__table__.delete().where(
+                    models.Entrega.origem_unidade == plano_entregas.origem_unidade,
+                    models.Entrega.cod_unidade_autorizadora
+                    == plano_entregas.cod_unidade_autorizadora,
+                    models.Entrega.id_plano_entregas
+                    == plano_entregas.id_plano_entregas,
+                )
+            )
+            if entregas_values:
+                await session.execute(insert(models.Entrega), entregas_values)
+
             result = await session.execute(
                 select(models.PlanoEntregas)
                 .filter_by(origem_unidade=plano_entregas.origem_unidade)
@@ -628,19 +694,25 @@ async def update_plano_entregas(
                 )
                 .filter_by(id_plano_entregas=plano_entregas.id_plano_entregas)
             )
-            db_plano_entregas = result.unique().scalar_one()
-            await session.delete(db_plano_entregas)
-            await session.flush()
+            db_plano_entregas_atualizado = result.unique().scalar_one()
 
-            for entrega in db_plano_entregas_atualizado.entregas:
-                session.add(entrega)
+        return (
+            schemas.PlanoEntregasSchema.model_validate(db_plano_entregas_atualizado),
+            created,
+        )
 
-            session.add(db_plano_entregas_atualizado)
 
-            await session.flush()
-
-        await session.refresh(db_plano_entregas_atualizado)
-        return schemas.PlanoEntregasSchema.model_validate(db_plano_entregas_atualizado)
+# async def update_plano_entregas(
+#     db_session: DbContextManager,
+#     plano_entregas: schemas.PlanoEntregasSchema,
+# ) -> schemas.PlanoEntregasSchema:
+#     """Atualiza um plano de entregas pelo fluxo único de upsert."""
+#     db_plano_entregas, _ = await upsert_plano_entregas(
+#         db_session=db_session,
+#         plano_entregas=plano_entregas,
+#         update_year_validation_cutoff_date=date.max,
+#     )
+#     return db_plano_entregas
 
 
 async def get_participante(

--- a/src/crud.py
+++ b/src/crud.py
@@ -4,12 +4,14 @@ from datetime import datetime, date
 from typing import Optional
 
 from sqlalchemy import select, and_, func
+from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.sql import text
 from sqlalchemy.exc import IntegrityError
 from fastapi import HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 import models, schemas
 from db_config import DbContextManager, sync_engine
+from util import over_a_year
 
 
 async def get_plano_trabalho(

--- a/src/crud.py
+++ b/src/crud.py
@@ -201,63 +201,227 @@ async def _build_plano_trabalho_model(
     return db_plano
 
 
-async def create_plano_trabalho(
+# async def create_plano_trabalho(
+#     db_session: DbContextManager,
+#     plano_trabalho: schemas.PlanoTrabalhoSchema,
+# ) -> schemas.PlanoTrabalhoSchema:
+#     """Cria um plano de trabalho definido pelos dados do schema Pydantic
+#     plano_trabalho.
+
+#     Args:
+#         db_session (DbContextManager): Context manager para a sessão
+#             async do SQL Alchemy.
+#         plano_trabalho (schemas.PlanoTrabalhoSchema): Dados do plano
+#             de trabalho como um esquema Pydantic.
+
+#     Returns:
+#         schemas.PlanoTrabalhoSchema: Esquema Pydantic do Plano de Trabalho
+#             com os dados que foram gravados no banco.
+#     """
+#     creation_timestamp = datetime.now()
+#     async with db_session as session:
+#         db_plano_trabalho = await _build_plano_trabalho_model(
+#             session, plano_trabalho, creation_timestamp
+#         )
+#         session.add(db_plano_trabalho)
+#         try:
+#             await session.commit()
+#         except IntegrityError as e:
+#             raise HTTPException(
+#                 status_code=422,
+#                 detail="Alteração rejeitada por violar regras de integridade",
+#             ) from e
+#         await session.refresh(db_plano_trabalho)
+#     return schemas.PlanoTrabalhoSchema.model_validate(db_plano_trabalho)
+
+
+async def upsert_plano_trabalho(
     db_session: DbContextManager,
     plano_trabalho: schemas.PlanoTrabalhoSchema,
-) -> schemas.PlanoTrabalhoSchema:
-    """Cria um plano de trabalho definido pelos dados do schema Pydantic
-    plano_trabalho.
-
-    Args:
-        db_session (DbContextManager): Context manager para a sessão
-            async do SQL Alchemy.
-        plano_trabalho (schemas.PlanoTrabalhoSchema): Dados do plano
-            de trabalho como um esquema Pydantic.
-
-    Returns:
-        schemas.PlanoTrabalhoSchema: Esquema Pydantic do Plano de Trabalho
-            com os dados que foram gravados no banco.
-    """
-    creation_timestamp = datetime.now()
-    async with db_session as session:
-        db_plano_trabalho = await _build_plano_trabalho_model(
-            session, plano_trabalho, creation_timestamp
-        )
-        session.add(db_plano_trabalho)
-        try:
-            await session.commit()
-        except IntegrityError as e:
-            raise HTTPException(
-                status_code=422,
-                detail="Alteração rejeitada por violar regras de integridade",
-            ) from e
-        await session.refresh(db_plano_trabalho)
-    return schemas.PlanoTrabalhoSchema.model_validate(db_plano_trabalho)
-
-
-async def update_plano_trabalho(
-    db_session: DbContextManager,
-    plano_trabalho: schemas.PlanoTrabalhoSchema,
-) -> schemas.PlanoTrabalhoSchema:
-    """Atualiza um plano de trabalho conforme os dados recebidos no
+    update_year_validation_cutoff_date: date,
+) -> tuple[schemas.PlanoTrabalhoSchema, bool]:
+    """Cria ou atualiza um plano de trabalho conforme os dados recebidos no
     esquema Pydantic em plano_trabalho.
 
-    Os dados existentes são primeiro apagados do banco para depois
-    inserir os dados recebidos.
+    O registro do plano é gravado com upsert para evitar conflitos de
+    integridade em transações concorrentes. As contribuições e avaliações
+    existentes são apagadas e recriadas dentro da mesma transação.
 
     Args:
         db_session (DbContextManager): Context manager para a sessão
             async do SQL Alchemy.
         plano_trabalho (schemas.PlanoTrabalhoSchema): Dados do plano
             de trabalho como um esquema Pydantic.
+        update_year_validation_cutoff_date (date): Data de corte para aplicar
+            a validação de período maior que 1 ano.
 
     Returns:
-        schemas.PlanoTrabalhoSchema: Esquema Pydantic do Plano de Trabalho
-            com o retorno de create_plano_trabalho.
+        tuple[schemas.PlanoTrabalhoSchema, bool]: Esquema Pydantic do Plano
+            de Trabalho e booleano indicando se foi criado.
     """
-    creation_timestamp = datetime.now()
+    timestamp = datetime.now()
+    plano_values = plano_trabalho.model_dump(
+        exclude={"contribuicoes", "avaliacoes_registros_execucao"}
+    )
+    plano_values["data_insercao"] = timestamp
+    plano_identity = {
+        "origem_unidade_pt": plano_trabalho.origem_unidade,
+        "cod_unidade_autorizadora_pt": plano_trabalho.cod_unidade_autorizadora,
+        "id_plano_trabalho": plano_trabalho.id_plano_trabalho,
+    }
+    contribuicoes_values = [
+        {
+            **contribuicao.model_dump(),
+            **plano_identity,
+            "data_insercao": timestamp,
+        }
+        for contribuicao in (plano_trabalho.contribuicoes or [])
+    ]
+    avaliacoes_values = [
+        {
+            **avaliacao.model_dump(),
+            **plano_identity,
+            "data_insercao": timestamp,
+        }
+        for avaliacao in (plano_trabalho.avaliacoes_registros_execucao or [])
+    ]
+
     async with db_session as session:
         async with session.begin():
+            result = await session.execute(
+                select(models.Participante.matricula_siape)
+                .filter_by(origem_unidade=plano_trabalho.origem_unidade)
+                .filter_by(
+                    cod_unidade_autorizadora=plano_trabalho.cod_unidade_autorizadora
+                )
+                .filter_by(matricula_siape=plano_trabalho.matricula_siape)
+                .filter_by(
+                    cod_unidade_lotacao=plano_trabalho.cod_unidade_lotacao_participante
+                )
+            )
+            participante_exists = result.scalar_one_or_none()
+            if not participante_exists:
+                raise ValueError(
+                    "Plano de Trabalho faz referência a participante inexistente.\n"
+                    f" origem_unidade: {plano_trabalho.origem_unidade}\n"
+                    f" cod_unidade_autorizadora: "
+                    f"{plano_trabalho.cod_unidade_autorizadora}\n"
+                    f" matricula_siape: {plano_trabalho.matricula_siape}\n"
+                    f" cod_unidade_lotacao: "
+                    f"{plano_trabalho.cod_unidade_lotacao_participante}"
+                )
+
+            for contribuicao in plano_trabalho.contribuicoes or []:
+                if (
+                    contribuicao.tipo_contribuicao == 1
+                    and contribuicao.id_plano_entregas
+                    and contribuicao.id_entrega
+                ):
+                    result = await session.execute(
+                        select(models.Entrega)
+                        .filter_by(origem_unidade=plano_trabalho.origem_unidade)
+                        .filter_by(
+                            cod_unidade_autorizadora=(
+                                plano_trabalho.cod_unidade_autorizadora
+                            )
+                        )
+                        .filter_by(id_plano_entregas=contribuicao.id_plano_entregas)
+                        .filter_by(id_entrega=contribuicao.id_entrega)
+                    )
+                    db_entrega = result.scalars().unique().one_or_none()
+                    if not db_entrega:
+                        raise ValueError(
+                            "Contribuição do Plano de Trabalho faz referência a "
+                            "entrega inexistente. "
+                            f"origem_unidade: {plano_trabalho.origem_unidade} "
+                            f"cod_unidade_autorizadora: "
+                            f"{plano_trabalho.cod_unidade_autorizadora} "
+                            f"id_plano_entregas: {contribuicao.id_plano_entregas} "
+                            f"id_entrega: {contribuicao.id_entrega}"
+                        )
+
+            result = await session.execute(
+                select(models.PlanoTrabalho.id_plano_trabalho)
+                .filter_by(origem_unidade=plano_trabalho.origem_unidade)
+                .filter_by(
+                    cod_unidade_autorizadora=plano_trabalho.cod_unidade_autorizadora
+                )
+                .filter_by(id_plano_trabalho=plano_trabalho.id_plano_trabalho)
+            )
+            plano_exists = result.scalar_one_or_none() is not None
+            created = not plano_exists
+            if (
+                over_a_year(plano_trabalho.data_inicio, plano_trabalho.data_termino)
+                == 1
+            ):
+                if (
+                    not plano_exists
+                    or plano_trabalho.data_inicio > update_year_validation_cutoff_date
+                ):
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            "Plano de trabalho não pode abranger período "
+                            "maior que 1 ano"
+                        ),
+                    )
+
+            try:
+                insert_stmt = insert(models.PlanoTrabalho).values(**plano_values)
+                update_values = {
+                    column.name: insert_stmt.excluded[column.name]
+                    for column in models.PlanoTrabalho.__table__.columns
+                    if (
+                        not column.primary_key
+                        and column.name not in ("data_insercao", "data_atualizacao")
+                    )
+                }
+                update_values["data_atualizacao"] = timestamp
+                await session.execute(
+                    insert_stmt.on_conflict_do_update(
+                        index_elements=[
+                            "origem_unidade",
+                            "cod_unidade_autorizadora",
+                            "id_plano_trabalho",
+                        ],
+                        set_=update_values,
+                    )
+                )
+
+                await session.execute(
+                    models.Contribuicao.__table__.delete().where(
+                        models.Contribuicao.origem_unidade_pt
+                        == plano_trabalho.origem_unidade,
+                        models.Contribuicao.cod_unidade_autorizadora_pt
+                        == plano_trabalho.cod_unidade_autorizadora,
+                        models.Contribuicao.id_plano_trabalho
+                        == plano_trabalho.id_plano_trabalho,
+                    )
+                )
+                await session.execute(
+                    models.AvaliacaoRegistrosExecucao.__table__.delete().where(
+                        models.AvaliacaoRegistrosExecucao.origem_unidade_pt
+                        == plano_trabalho.origem_unidade,
+                        models.AvaliacaoRegistrosExecucao.cod_unidade_autorizadora_pt
+                        == plano_trabalho.cod_unidade_autorizadora,
+                        models.AvaliacaoRegistrosExecucao.id_plano_trabalho
+                        == plano_trabalho.id_plano_trabalho,
+                    )
+                )
+                if contribuicoes_values:
+                    await session.execute(
+                        insert(models.Contribuicao), contribuicoes_values
+                    )
+                if avaliacoes_values:
+                    await session.execute(
+                        insert(models.AvaliacaoRegistrosExecucao), avaliacoes_values
+                    )
+            except IntegrityError as e:
+                raise HTTPException(
+                    status_code=422,
+                    detail="Alteração rejeitada por violar regras de integridade",
+                ) from e
+
             result = await session.execute(
                 select(models.PlanoTrabalho)
                 .filter_by(origem_unidade=plano_trabalho.origem_unidade)
@@ -266,23 +430,22 @@ async def update_plano_trabalho(
                 )
                 .filter_by(id_plano_trabalho=plano_trabalho.id_plano_trabalho)
             )
-            db_plano_trabalho = result.unique().scalar_one()
-            await session.delete(db_plano_trabalho)
-            await session.flush()
+            db_plano_atualizado = result.unique().scalar_one()
 
-            db_plano_atualizado = await _build_plano_trabalho_model(
-                session, plano_trabalho, creation_timestamp
-            )
-            session.add(db_plano_atualizado)
-            try:
-                await session.flush()
-            except IntegrityError as e:
-                raise HTTPException(
-                    status_code=422,
-                    detail="Alteração rejeitada por violar regras de integridade",
-                ) from e
-        await session.refresh(db_plano_atualizado)
-    return schemas.PlanoTrabalhoSchema.model_validate(db_plano_atualizado)
+    return schemas.PlanoTrabalhoSchema.model_validate(db_plano_atualizado), created
+
+
+# async def update_plano_trabalho(
+#     db_session: DbContextManager,
+#     plano_trabalho: schemas.PlanoTrabalhoSchema,
+# ) -> schemas.PlanoTrabalhoSchema:
+#     """Atualiza um plano de trabalho pelo fluxo único de upsert."""
+#     db_plano_trabalho, _ = await upsert_plano_trabalho(
+#         db_session=db_session,
+#         plano_trabalho=plano_trabalho,
+#         update_year_validation_cutoff_date=date.max,
+#     )
+#     return db_plano_trabalho
 
 
 async def get_plano_entregas(

--- a/tests/plano_entregas/core_test.py
+++ b/tests/plano_entregas/core_test.py
@@ -9,7 +9,9 @@ from httpx import Client, Response
 from fastapi import status as http_status
 
 import pytest
+from sqlalchemy import text
 
+from db_config import sync_engine
 from util import assert_error_message
 from ..conftest import MAX_BIGINT
 
@@ -231,6 +233,47 @@ class TestCreatePlanoEntrega(BasePETest):
         assert response.status_code == http_status.HTTP_200_OK
         assert response.json()["avaliacao"] == 3
         assert response.json()["data_avaliacao"] == "2024-08-15"
+
+    def test_plano_entregas_datas_insercao_atualizacao(self):
+        """Verifica datas técnicas de criação e atualização do plano."""
+
+        response = self.put_plano_entregas(self.input_pe)
+        assert response.status_code == http_status.HTTP_201_CREATED
+
+        query = text(
+            """
+            SELECT data_insercao, data_atualizacao
+            FROM plano_entregas
+            WHERE origem_unidade = :origem_unidade
+              AND cod_unidade_autorizadora = :cod_unidade_autorizadora
+              AND id_plano_entregas = :id_plano_entregas
+            """
+        )
+        params = {
+            "origem_unidade": self.input_pe["origem_unidade"],
+            "cod_unidade_autorizadora": self.input_pe["cod_unidade_autorizadora"],
+            "id_plano_entregas": self.input_pe["id_plano_entregas"],
+        }
+
+        with sync_engine.connect() as conn:
+            db_plano = conn.execute(query, params).mappings().one()
+
+        data_insercao = db_plano["data_insercao"]
+        assert data_insercao is not None
+        assert db_plano["data_atualizacao"] is None
+
+        input_pe = deepcopy(self.input_pe)
+        input_pe["avaliacao"] = 3
+        input_pe["data_avaliacao"] = "2024-08-15"
+        response = self.put_plano_entregas(input_pe)
+        assert response.status_code == http_status.HTTP_200_OK
+
+        with sync_engine.connect() as conn:
+            db_plano = conn.execute(query, params).mappings().one()
+
+        assert db_plano["data_insercao"] == data_insercao
+        assert db_plano["data_atualizacao"] is not None
+        assert db_plano["data_atualizacao"] >= data_insercao
 
     @pytest.mark.parametrize("omitted_fields", enumerate(FIELDS_ENTREGA["optional"]))
     def test_create_plano_entregas_entrega_omit_optional_fields(self, omitted_fields):

--- a/tests/plano_trabalho/core_test.py
+++ b/tests/plano_trabalho/core_test.py
@@ -10,7 +10,9 @@ from httpx import Client, Response
 from fastapi import status
 
 import pytest
+from sqlalchemy import text
 
+from db_config import sync_engine
 from util import assert_error_message
 from ..conftest import MAX_INT, MAX_BIGINT
 
@@ -248,6 +250,47 @@ class TestCreatePlanoTrabalho(BasePTTest):
 
         assert response.status_code == status.HTTP_200_OK
         self.assert_equal_plano_trabalho(response.json(), self.input_pt)
+
+    def test_plano_trabalho_datas_insercao_atualizacao(self):
+        """Verifica datas técnicas de criação e atualização do plano."""
+
+        response = self.put_plano_trabalho(self.input_pt)
+        assert response.status_code == status.HTTP_201_CREATED
+
+        query = text(
+            """
+            SELECT data_insercao, data_atualizacao
+            FROM plano_trabalho
+            WHERE origem_unidade = :origem_unidade
+              AND cod_unidade_autorizadora = :cod_unidade_autorizadora
+              AND id_plano_trabalho = :id_plano_trabalho
+            """
+        )
+        params = {
+            "origem_unidade": self.input_pt["origem_unidade"],
+            "cod_unidade_autorizadora": self.input_pt["cod_unidade_autorizadora"],
+            "id_plano_trabalho": self.input_pt["id_plano_trabalho"],
+        }
+
+        with sync_engine.connect() as conn:
+            db_plano = conn.execute(query, params).mappings().one()
+
+        data_insercao = db_plano["data_insercao"]
+        assert data_insercao is not None
+        assert db_plano["data_atualizacao"] is None
+
+        input_pt = deepcopy(self.input_pt)
+        input_pt["status"] = 4
+        input_pt["data_termino"] = "2024-06-30"
+        response = self.put_plano_trabalho(input_pt)
+        assert response.status_code == status.HTTP_200_OK
+
+        with sync_engine.connect() as conn:
+            db_plano = conn.execute(query, params).mappings().one()
+
+        assert db_plano["data_insercao"] == data_insercao
+        assert db_plano["data_atualizacao"] is not None
+        assert db_plano["data_atualizacao"] >= data_insercao
 
     @pytest.mark.parametrize(
         "missing_fields", enumerate(FIELDS_PLANO_TRABALHO["mandatory"])


### PR DESCRIPTION
Altera o fluxo de gravação de Plano de Entregas e Plano de Trabalho para utilizar upsert, evitando o fluxo anterior baseado em apagar e recriar o registro principal durante atualizações, a fim de evitar erros de integridade por transações concorrentes.

As tabelas filhas continuam sendo recriadas dentro da transação, garantindo que os dados enviados na requisição substituam integralmente os vínculos anteriores.

Principais alterações

- Cria fluxo único de upsert para Plano de Entregas.
- Cria fluxo único de upsert para Plano de Trabalho.
- Remove a bifurcação get -> create/update dos endpoints afetados.
- Passa a preencher data_atualizacao quando houver atualização.
- Mantém data_insercao preservada em atualizações.
- Move algumas validações de negócio para dentro do CRUD.
- Adiciona testes para validar data_insercao e data_atualizacao.

Fix #240 